### PR TITLE
Add OntoPortal importer

### DIFF
--- a/docs/source/contrib.rst
+++ b/docs/source/contrib.rst
@@ -1,0 +1,4 @@
+Contrib
+=======
+
+.. automodapi:: sssom_pydantic.contrib.ontoportal

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ SSSOM Pydantic |release| Documentation
     installation
     usage
     cli
+    contrib
 
 Indices and Tables
 ------------------

--- a/src/sssom_pydantic/contrib/ontoportal.py
+++ b/src/sssom_pydantic/contrib/ontoportal.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import curies
 from curies import Reference
-from curies.vocabulary import has_dbxref, lexical_matching_process
+from curies.vocabulary import exact_match, lexical_matching_process
 
 from sssom_pydantic import MappingTool, SemanticMapping
 
@@ -18,11 +18,34 @@ logger = logging.getLogger(__name__)
 
 
 def from_bioportal(
-    o1: str, o2: str, *, converter: curies.Converter | None = None
+    o1: str,
+    o2: str,
+    *,
+    converter: curies.Converter | None = None,
+    client: ontoportal_client.BioPortalClient | None = None,
 ) -> list[SemanticMapping]:
-    from ontoportal_client import BioPortalClient
+    """Get mappings from BioPortal.
 
-    return from_ontoportal(o1, o2, client=BioPortalClient(), converter=converter)
+    :param o1: The first ontology
+    :param o2: The second ontology
+    :param client: A pre-instantiated BioPortal client. If not given, will try to
+        automatically construct one. Note that this requires having an API key
+        configured.
+    :param converter: A converter for parsing URIs
+
+    :returns: A list of semantic mappings.
+
+    .. warning::
+
+        BioPortal contains irrelevant mappings, i.e., ones that are made between
+        imported terms. Therefore, you should check that the ontologies match the parsed
+        results
+    """
+    if client is None:
+        from ontoportal_client import BioPortalClient
+
+        client = BioPortalClient()
+    return from_ontoportal(o1, o2, client=client, converter=converter)
 
 
 def from_ontoportal(
@@ -32,6 +55,25 @@ def from_ontoportal(
     converter: curies.Converter | None = None,
     client: ontoportal_client.Client,
 ) -> list[SemanticMapping]:
+    """Get mappings from an OntoPortal instance.
+
+    :param o1: The first ontology
+    :param o2: The second ontology
+    :param client: A pre-instantiated OntoPortal client, e.g., to BioPortal, AgroPortal,
+        EcoPortal, etc.
+    :param converter: A converter for parsing URIs
+
+    :returns: A list of semantic mappings.
+
+    .. warning::
+
+        OntoPortal's mapping data model includes any mappings between terms that have
+        been imported into the ontologies, meaning that you should filter post-facto to
+        only keep mappings whose subject/object match the query ontologies.
+
+        This isn't possible to do directly because OntoPortal's data model does not
+        contain a prefix map nor information about the defining ontology for a term
+    """
     if converter is None:
         import bioregistry
 
@@ -58,12 +100,13 @@ def _process(data: dict[str, Any], converter: curies.Converter) -> SemanticMappi
         # see https://www.bioontology.org/wiki/LOOM
         mapping_tool = MappingTool(name="LOOM")
         justification = lexical_matching_process
+        predicate = exact_match
     else:
         logger.warning("unhandled mapping tool: %s", tool)
         return None
     return SemanticMapping(
         subject=subject,
-        predicate=has_dbxref,
+        predicate=predicate,
         object=obj,
         justification=justification,
         mapping_tool=mapping_tool,
@@ -77,7 +120,3 @@ def _process_class(data: dict[str, Any], converter: curies.Converter) -> Referen
         logger.warning("could not parse: %s", uri)
         return None
     return reference_tuple.to_pydantic()
-
-
-if __name__ == "__main__":
-    from_bioportal("SNOMEDCT", "AERO")

--- a/src/sssom_pydantic/contrib/ontoportal.py
+++ b/src/sssom_pydantic/contrib/ontoportal.py
@@ -45,6 +45,43 @@ def from_bioportal(
         configured.
 
     :returns: A list of semantic mappings.
+
+        .. warning::
+
+            BioPortal doesn't provide an option to only return mappings between entities
+            defined in the two given ontologies. For example, if you ask for mappings
+            between ``SNOMEDCT`` and ``AERO``, you will also get mappings between OGMS
+            and SNOMEDCT (because OGMS terms are imported in AERO).
+
+            This means that you should probably apply post-hoc filtering to only retain
+            relevant mappings.
+
+
+    Simple usage:
+
+    .. code-block:: python
+
+        import bioregistry
+        from sssom_pydantic.contrib.ontoportal import from_bioportal
+
+        converter = bioregistry.get_converter()
+        mappings = from_bioportal("SNOMEDCT", "AERO", converter=converter)
+
+    Usage with explicitly defined converter, which implicitly filters only to relevant
+    mappings:
+
+    .. code-block:: python
+
+        import curies
+        from sssom_pydantic.contrib.ontoportal import from_bioportal
+
+        converter = curies.Converter.from_prefix_map(
+            {
+                "AERO": "http://purl.obolibrary.org/obo/AERO_",
+                "SNOMEDCT": "http://purl.bioontology.org/ontology/SNOMEDCT/",
+            }
+        )
+        mappings = from_bioportal("SNOMEDCT", "AERO", converter=converter)
     """
     if client is None:
         from ontoportal_client import BioPortalClient
@@ -88,6 +125,37 @@ def from_ontoportal(
 
             This means that you should probably apply post-hoc filtering to only retain
             relevant mappings.
+
+
+    Simple usage:
+
+    .. code-block:: python
+
+        import bioregistry
+        from ontoportal_client import BioPortalClient
+        from sssom_pydantic.contrib.ontoportal import from_ontoportal
+
+        converter = bioregistry.get_converter()
+        client = BioPortalClient()
+        mappings = from_ontoportal("SNOMEDCT", "AERO", converter=converter, client=client)
+
+    Usage with explicitly defined converter, which implicitly filters only to relevant
+    mappings:
+
+    .. code-block:: python
+
+        import curies
+        from ontoportal_client import BioPortalClient
+        from sssom_pydantic.contrib.ontoportal import from_ontoportal
+
+        converter = curies.Converter.from_prefix_map(
+            {
+                "AERO": "http://purl.obolibrary.org/obo/AERO_",
+                "SNOMEDCT": "http://purl.bioontology.org/ontology/SNOMEDCT/",
+            }
+        )
+        client = BioPortalClient()
+        mappings = from_bioportal("SNOMEDCT", "AERO", converter=converter, client=client)
     """
     rv = []
     for data in client.get_mappings(ontology_1, ontology_2):

--- a/src/sssom_pydantic/contrib/ontoportal.py
+++ b/src/sssom_pydantic/contrib/ontoportal.py
@@ -1,0 +1,83 @@
+"""Get mappings from OntoPortal."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import curies
+from curies import Reference
+from curies.vocabulary import has_dbxref, lexical_matching_process
+
+from sssom_pydantic import MappingTool, SemanticMapping
+
+if TYPE_CHECKING:
+    import ontoportal_client
+
+logger = logging.getLogger(__name__)
+
+
+def from_bioportal(
+    o1: str, o2: str, *, converter: curies.Converter | None = None
+) -> list[SemanticMapping]:
+    from ontoportal_client import BioPortalClient
+
+    return from_ontoportal(o1, o2, client=BioPortalClient(), converter=converter)
+
+
+def from_ontoportal(
+    o1: str,
+    o2: str,
+    *,
+    converter: curies.Converter | None = None,
+    client: ontoportal_client.Client,
+) -> list[SemanticMapping]:
+    if converter is None:
+        import bioregistry
+
+        converter = bioregistry.get_converter()
+
+    rv = []
+    for data in client.get_mappings(o1, o2):
+        if semantic_mapping := _process(data, converter=converter):
+            rv.append(semantic_mapping)
+    return rv
+
+
+def _process(data: dict[str, Any], converter: curies.Converter) -> SemanticMapping | None:
+    subject_raw, target_raw = data["classes"]
+    subject = _process_class(subject_raw, converter)
+    if subject is None:
+        return None
+    obj = _process_class(target_raw, converter)
+    if obj is None:
+        return None
+
+    tool = data["source"]
+    if tool == "LOOM":
+        # see https://www.bioontology.org/wiki/LOOM
+        mapping_tool = MappingTool(name="LOOM")
+        justification = lexical_matching_process
+    else:
+        logger.warning("unhandled mapping tool: %s", tool)
+        return None
+    return SemanticMapping(
+        subject=subject,
+        predicate=has_dbxref,
+        object=obj,
+        justification=justification,
+        mapping_tool=mapping_tool,
+    )
+
+
+def _process_class(data: dict[str, Any], converter: curies.Converter) -> Reference | None:
+    uri = data["@id"]
+    reference_tuple = converter.parse_uri(uri)
+    if reference_tuple is None:
+        logger.warning("could not parse: %s", uri)
+        return None
+    return reference_tuple.to_pydantic()
+
+
+if __name__ == "__main__":
+    from_bioportal("SNOMEDCT", "AERO")

--- a/src/sssom_pydantic/contrib/ontoportal.py
+++ b/src/sssom_pydantic/contrib/ontoportal.py
@@ -1,4 +1,11 @@
-"""Get mappings from OntoPortal."""
+"""Get mappings from an OntoPortal instance.
+
+.. code-block:: python
+
+    from sssom_pydantic.contrib.ontoportal import from_bioportal
+
+    mappings = from_bioportal("SNOMEDCT", "AERO")
+"""
 
 from __future__ import annotations
 
@@ -115,7 +122,7 @@ def _process(data: dict[str, Any], converter: curies.Converter) -> SemanticMappi
 
 def _process_class(data: dict[str, Any], converter: curies.Converter) -> Reference | None:
     uri = data["@id"]
-    reference_tuple = converter.parse_uri(uri)
+    reference_tuple: curies.ReferenceTuple | None = converter.parse_uri(uri)
     if reference_tuple is None:
         logger.warning("could not parse: %s", uri)
         return None

--- a/tests/test_contrib/ontoportal_example.json
+++ b/tests/test_contrib/ontoportal_example.json
@@ -1,0 +1,77 @@
+{
+  "id": null,
+  "source": "LOOM",
+  "classes": [
+    {
+      "@id": "http://purl.obolibrary.org/obo/ogms/OMRE_0000023",
+      "@type": "http://www.w3.org/2002/07/owl#Class",
+      "links": {
+        "self": "https://data.bioontology.org/ontologies/AERO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fogms%2FOMRE_0000023",
+        "ontology": "https://data.bioontology.org/ontologies/AERO",
+        "children": "https://data.bioontology.org/ontologies/AERO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fogms%2FOMRE_0000023/children",
+        "parents": "https://data.bioontology.org/ontologies/AERO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fogms%2FOMRE_0000023/parents",
+        "descendants": "https://data.bioontology.org/ontologies/AERO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fogms%2FOMRE_0000023/descendants",
+        "ancestors": "https://data.bioontology.org/ontologies/AERO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fogms%2FOMRE_0000023/ancestors",
+        "instances": "https://data.bioontology.org/ontologies/AERO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fogms%2FOMRE_0000023/instances",
+        "tree": "https://data.bioontology.org/ontologies/AERO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fogms%2FOMRE_0000023/tree",
+        "notes": "https://data.bioontology.org/ontologies/AERO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fogms%2FOMRE_0000023/notes",
+        "mappings": "https://data.bioontology.org/ontologies/AERO/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fogms%2FOMRE_0000023/mappings",
+        "ui": "http://bioportal.bioontology.org/ontologies/AERO?p=classes&conceptid=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fogms%2FOMRE_0000023",
+        "@context": {
+          "self": "http://www.w3.org/2002/07/owl#Class",
+          "ontology": "http://data.bioontology.org/metadata/Ontology",
+          "children": "http://www.w3.org/2002/07/owl#Class",
+          "parents": "http://www.w3.org/2002/07/owl#Class",
+          "descendants": "http://www.w3.org/2002/07/owl#Class",
+          "ancestors": "http://www.w3.org/2002/07/owl#Class",
+          "instances": "http://data.bioontology.org/metadata/Instance",
+          "tree": "http://www.w3.org/2002/07/owl#Class",
+          "notes": "http://data.bioontology.org/metadata/Note",
+          "mappings": "http://data.bioontology.org/metadata/Mapping",
+          "ui": "http://www.w3.org/2002/07/owl#Class"
+        }
+      },
+      "@context": {
+        "@vocab": "http://data.bioontology.org/metadata/",
+        "@language": "en"
+      }
+    },
+    {
+      "@id": "http://purl.bioontology.org/ontology/SNOMEDCT/3415004",
+      "@type": "http://www.w3.org/2002/07/owl#Class",
+      "links": {
+        "self": "https://data.bioontology.org/ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2F3415004",
+        "ontology": "https://data.bioontology.org/ontologies/SNOMEDCT",
+        "children": "https://data.bioontology.org/ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2F3415004/children",
+        "parents": "https://data.bioontology.org/ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2F3415004/parents",
+        "descendants": "https://data.bioontology.org/ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2F3415004/descendants",
+        "ancestors": "https://data.bioontology.org/ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2F3415004/ancestors",
+        "instances": "https://data.bioontology.org/ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2F3415004/instances",
+        "tree": "https://data.bioontology.org/ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2F3415004/tree",
+        "notes": "https://data.bioontology.org/ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2F3415004/notes",
+        "mappings": "https://data.bioontology.org/ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2F3415004/mappings",
+        "ui": "http://bioportal.bioontology.org/ontologies/SNOMEDCT?p=classes&conceptid=http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2F3415004",
+        "@context": {
+          "self": "http://www.w3.org/2002/07/owl#Class",
+          "ontology": "http://data.bioontology.org/metadata/Ontology",
+          "children": "http://www.w3.org/2002/07/owl#Class",
+          "parents": "http://www.w3.org/2002/07/owl#Class",
+          "descendants": "http://www.w3.org/2002/07/owl#Class",
+          "ancestors": "http://www.w3.org/2002/07/owl#Class",
+          "instances": "http://data.bioontology.org/metadata/Instance",
+          "tree": "http://www.w3.org/2002/07/owl#Class",
+          "notes": "http://data.bioontology.org/metadata/Note",
+          "mappings": "http://data.bioontology.org/metadata/Mapping",
+          "ui": "http://www.w3.org/2002/07/owl#Class"
+        }
+      },
+      "@context": {
+        "@vocab": "http://data.bioontology.org/metadata/",
+        "@language": "en"
+      }
+    }
+  ],
+  "process": null,
+  "@id": "",
+  "@type": "http://data.bioontology.org/metadata/Mapping"
+}

--- a/tests/test_contrib/test_ontoportal.py
+++ b/tests/test_contrib/test_ontoportal.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import curies
 from curies import Reference
-from curies.vocabulary import has_dbxref, lexical_matching_process
+from curies.vocabulary import exact_match, lexical_matching_process
 
 from sssom_pydantic import MappingTool, SemanticMapping
 from sssom_pydantic.contrib.ontoportal import _process
@@ -31,7 +31,7 @@ class TestBioportal(unittest.TestCase):
         self.assertIsNotNone(mapping)
         expected = SemanticMapping(
             subject=Reference(prefix="OMRE", identifier="0000023"),
-            predicate=has_dbxref,
+            predicate=exact_match,
             object=Reference(prefix="SNOMEDCT", identifier="3415004"),
             justification=lexical_matching_process,
             mapping_tool=MappingTool(name="LOOM"),

--- a/tests/test_contrib/test_ontoportal.py
+++ b/tests/test_contrib/test_ontoportal.py
@@ -1,0 +1,39 @@
+"""Tests for consuming OntoPortal mappings."""
+
+import json
+import unittest
+from pathlib import Path
+
+import curies
+from curies import Reference
+from curies.vocabulary import has_dbxref, lexical_matching_process
+
+from sssom_pydantic import MappingTool, SemanticMapping
+from sssom_pydantic.contrib.ontoportal import _process
+
+HERE = Path(__file__).parent.resolve()
+PATH = HERE.joinpath("ontoportal_example.json")
+
+
+class TestBioportal(unittest.TestCase):
+    """Test processing OntoPortal mappings."""
+
+    def test_process(self) -> None:
+        """Test processing OntoPortal mappings."""
+        converter = curies.Converter.from_prefix_map(
+            {
+                "OMRE": "http://purl.obolibrary.org/obo/ogms/OMRE_",
+                "SNOMEDCT": "http://purl.bioontology.org/ontology/SNOMEDCT/",
+            }
+        )
+        data = json.loads(PATH.read_text())
+        mapping = _process(data, converter)
+        self.assertIsNotNone(mapping)
+        expected = SemanticMapping(
+            subject=Reference(prefix="OMRE", identifier="0000023"),
+            predicate=has_dbxref,
+            object=Reference(prefix="SNOMEDCT", identifier="3415004"),
+            justification=lexical_matching_process,
+            mapping_tool=MappingTool(name="LOOM"),
+        )
+        self.assertEqual(expected, mapping)


### PR DESCRIPTION
This PR imports a module for importing from OntoPortal. It has an explicit wrapper for BioPortal, but any client from [`ontoportal_client`](https://github.com/cthoyt/ontoportal-client) can be used (e.g., AgroPortal, EcoPortal, IndustryPortal, etc.)

Example usage:


```python
import bioregistry
from sssom_pydantic.contrib.ontoportal import from_bioportal

converter = bioregistry.get_converter()
mappings = from_bioportal("SNOMEDCT", "AERO", converter=converter)
```

You have to bring your own `curies.Converter` because OntoPortal's data model doesn't return a meaningful prefix map for parsing IRIs. The Bioregistry is a good and quick way to get a comprehensive prefix map.

> [!Warning]
> BioPortal doesn't provide an option to only return mappings between entities defined in the two given ontologies. For example, if you ask for mappings between ``SNOMEDCT`` and ``AERO``, you will also get mappings between OGMS and SNOMEDCT (because OGMS terms are imported in AERO).
>
> This means that you should probably apply post-hoc filtering to only retain relevant mappings.

One way to do this is to rely on the definition of the converter, since any mappings with subject or objects with URIs that can't be parsed are discarded:

```python
import curies
from sssom_pydantic.contrib.ontoportal import from_bioportal

converter = curies.Converter.from_prefix_map(
    {
        "AERO": "http://purl.obolibrary.org/obo/AERO_",
        "SNOMEDCT": "http://purl.bioontology.org/ontology/SNOMEDCT/",
    }
)
mappings = from_bioportal("SNOMEDCT", "AERO", converter=converter)
```

