### PR TITLE
Add standardization to semantic mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ license-files = [
 requires-python = ">=3.10"
 dependencies = [
     "pydantic",
-    "curies>=0.12.1",
+    "curies>=0.12.5",
     "pyyaml",
     "pystow",
 ]

--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -6,7 +6,7 @@ import datetime
 import functools
 import warnings
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias, Self
+from typing import Any, Literal, Self, TypeAlias
 
 import curies
 from curies import NamableReference, Reference, Triple
@@ -359,7 +359,25 @@ class SemanticMapping(CoreSemanticMapping, SemanticallyStandardizable):
 
     def standardize(self, converter: curies.Converter) -> Self:
         """Standardize."""
-        pass
+        update = {}
+        for _field in self.__class__.model_fields:
+            pass
+        return self.model_copy(update=update)
+
+
+def _safe_standarize(reference: Reference | None, converter: curies.Converter) -> Reference | None:
+    if reference is None:
+        return None
+    return converter.standardize_reference(reference, strict=True)
+
+
+def _st_list(
+    references: list[Reference] | None, converter: curies.Converter
+) -> list[Reference] | None:
+    if references is None:
+        return None
+    return [converter.standardize_reference(r, strict=True) for r in references]
+
 
 #: A predicate for a semantic mapping
 SemanticMappingPredicate: TypeAlias = Callable[[SemanticMapping], bool]

--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -6,10 +6,11 @@ import datetime
 import functools
 import warnings
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, TypeAlias, Self
 
 import curies
 from curies import NamableReference, Reference, Triple
+from curies.mixins import SemanticallyStandardizable
 from curies.vocabulary import matching_processes
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -197,7 +198,7 @@ def _join(references: list[Reference] | None) -> list[str] | None:
     return [r.curie for r in references]
 
 
-class SemanticMapping(CoreSemanticMapping):
+class SemanticMapping(CoreSemanticMapping, SemanticallyStandardizable):
     """Represents all fields for SSSOM.."""
 
     model_config = ConfigDict(frozen=True)
@@ -356,6 +357,9 @@ class SemanticMapping(CoreSemanticMapping):
             similarity_score=self.similarity_score,
         )
 
+    def standardize(self, converter: curies.Converter) -> Self:
+        """Standardize."""
+        pass
 
 #: A predicate for a semantic mapping
 SemanticMappingPredicate: TypeAlias = Callable[[SemanticMapping], bool]

--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -6,13 +6,14 @@ import datetime
 import functools
 import warnings
 from collections.abc import Callable
-from typing import Any, Literal, Self, TypeAlias
+from typing import Any, Literal, TypeAlias
 
 import curies
 from curies import NamableReference, Reference, Triple
 from curies.mixins import SemanticallyStandardizable
 from curies.vocabulary import matching_processes
 from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import Self
 
 from .constants import MULTIVALUED, PROPAGATABLE, Row
 from .models import Cardinality, Record

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import curies
+from curies import Reference
 from curies.vocabulary import charlie, exact_match, manual_mapping_curation
 from pydantic import BaseModel
 
@@ -205,12 +206,14 @@ class TestIO(unittest.TestCase):
             predicate=exact_match,
             object="mesh:C067604",
             justification=manual_mapping_curation,
+            authors=[Reference.from_curie("ORCiD:0000-0003-4423-4370")],
         )
         expected = SemanticMapping(
             subject="CHEBI:10001",
             predicate=exact_match,
             object="mesh:C067604",
             justification=manual_mapping_curation,
+            authors=[Reference.from_curie("orcid:0000-0003-4423-4370")],
         )
         converter = curies.Converter(
             [
@@ -224,6 +227,13 @@ class TestIO(unittest.TestCase):
                     prefix_synonyms=["MeSH"],
                     uri_prefix="http://id.nlm.nih.gov/mesh/",
                 ),
+                curies.Record(
+                    prefix="orcid",
+                    prefix_synonyms=["ORCiD"],
+                    uri_prefix="https://orcid.org/",
+                ),
+                curies.Record(prefix="skos", uri_prefix="http://www.w3.org/2004/02/skos/core#"),
+                curies.Record(prefix="semapv", uri_prefix="https://w3id.org/semapv/vocab/"),
             ]
         )
         self.assert_model_equal(expected, original.standardize(converter))


### PR DESCRIPTION
This PR adds the `curies.SemanticallyStandardizable` mixin to the semantic mapping class such that it can be reconfigured with a given converter