### PR TITLE
Add initial JSKOS I/O

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ ontoportal = [
 database = [
     "sqlmodel",
 ]
+jskos = ["jskos>=0.0.4"]
 fastapi = [
     "fastapi",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ ontoportal = [
 database = [
     "sqlmodel",
 ]
-jskos = ["jskos>=0.0.4"]
+jskos = ["jskos>=0.0.5"]
 fastapi = [
     "fastapi",
 ]

--- a/src/sssom_pydantic/contrib/jskos_export.py
+++ b/src/sssom_pydantic/contrib/jskos_export.py
@@ -2,13 +2,11 @@
 
 import subprocess
 import tempfile
-from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import curies
 import jskos
-from jskos import Concept
 
 import sssom_pydantic
 
@@ -18,64 +16,38 @@ if TYPE_CHECKING:
     from sssom_pydantic import MappingSet, MappingSetRecord, Metadata, SemanticMapping
 
 __all__ = [
-    "mapping_set_to_jskos",
-    "mapping_to_jskos",
-    "mapping_to_jskos_oracle",
-    "path_to_jskos_oracle",
+    "to_jskos",
 ]
 
 
-def mapping_set_to_jskos(
-    mappings: list[SemanticMapping], converter: curies.Converter, metadata: MappingSet
-) -> Concept:
-    """Convert a mapping set to JSKOS."""
-    rv = Concept(
-        identifier=[metadata.id],
-        license=[Concept(uri=metadata.license)],
-        mappings=[mapping_to_jskos(mapping, converter) for mapping in mappings],
-    )
-    return rv
-
-
-def mapping_to_jskos(mapping: SemanticMapping, converter: curies.Converter) -> jskos.Mapping:
-    """Convert a mapping to JSKOS."""
-    _r = partial(converter.expand_reference, strict=True)
-
-    return jskos.Mapping.model_validate(
-        {
-            "type": [_r(mapping.predicate)],
-            "from": Concept(member_set=[Concept(uri=_r(mapping.subject))]),
-            "to": Concept(member_set=[Concept(uri=_r(mapping.object))]),
-            "justification": _r(mapping.justification),
-        }
-    )
-
-
-def mapping_to_jskos_oracle(
-    mapping: SemanticMapping,
-    metadata: MappingSet | Metadata | MappingSetRecord | None,
-    converter: curies.Converter,
+def to_jskos(
+    mappings: SemanticMapping | list[SemanticMapping],
+    *,
+    metadata: MappingSet | Metadata | MappingSetRecord | None = None,
+    converter: curies.Converter | None = None,
 ) -> jskos.Concept:
-    """Convert a mapping to JSKOS using sssom-js."""
-    with tempfile.TemporaryDirectory() as td:
-        path = Path(td).joinpath("example.sssom.tsv")
+    """Convert mapping(s) to JSKOS using sssom-js."""
+    if isinstance(mappings, SemanticMapping):
+        mappings = [mappings]
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        path = Path(temporary_directory).joinpath("tmp.sssom.tsv")
         sssom_pydantic.write(
-            [mapping],
+            mappings,
             path,
             metadata=metadata,
             converter=converter,
         )
-        return path_to_jskos_oracle(path)
+        return _path_to_jskos(path)
 
 
-def path_to_jskos_oracle(path: Path) -> jskos.Concept:
+def _path_to_jskos(path: Path) -> jskos.Concept:
     """Convert SSSOM TSV to JSKOS using sssom-js."""
     import jskos
 
-    with tempfile.TemporaryDirectory() as td:
+    with tempfile.TemporaryDirectory() as temporary_directory:
         # Convert the SSSOM TSV to JSKOS using the sssom-js package
         # on NPM (https://www.npmjs.com/package/sssom-js)
-        jskos_path = Path(td).joinpath("example.sssom.json")
+        jskos_path = Path(temporary_directory).joinpath("tmp.sssom.json")
         result = subprocess.run(  # noqa:S603
             [  # noqa:S607
                 "npx",

--- a/src/sssom_pydantic/contrib/jskos_export.py
+++ b/src/sssom_pydantic/contrib/jskos_export.py
@@ -11,10 +11,11 @@ import jskos
 from jskos import Concept
 
 import sssom_pydantic
-from sssom_pydantic import MappingSet, SemanticMapping
 
 if TYPE_CHECKING:
     import jskos
+
+    from sssom_pydantic import MappingSet, MappingSetRecord, Metadata, SemanticMapping
 
 __all__ = [
     "mapping_set_to_jskos",
@@ -50,7 +51,11 @@ def mapping_to_jskos(mapping: SemanticMapping, converter: curies.Converter) -> j
     )
 
 
-def mapping_to_jskos_oracle(mapping: SemanticMapping, metadata, converter):
+def mapping_to_jskos_oracle(
+    mapping: SemanticMapping,
+    metadata: MappingSet | Metadata | MappingSetRecord | None,
+    converter: curies.Converter,
+) -> jskos.Concept:
     """Convert a mapping to JSKOS using sssom-js."""
     with tempfile.TemporaryDirectory() as td:
         path = Path(td).joinpath("example.sssom.tsv")

--- a/src/sssom_pydantic/contrib/jskos_export.py
+++ b/src/sssom_pydantic/contrib/jskos_export.py
@@ -1,5 +1,7 @@
 """Convert semantic mappings into JSKOS format."""
 
+from __future__ import annotations
+
 import subprocess
 import tempfile
 from pathlib import Path

--- a/src/sssom_pydantic/contrib/jskos_export.py
+++ b/src/sssom_pydantic/contrib/jskos_export.py
@@ -1,0 +1,96 @@
+"""Convert semantic mappings into JSKOS format."""
+
+import subprocess
+import tempfile
+from functools import partial
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import curies
+import jskos
+from jskos import Concept
+
+import sssom_pydantic
+from sssom_pydantic import MappingSet, SemanticMapping
+
+if TYPE_CHECKING:
+    import jskos
+
+__all__ = [
+    "mapping_set_to_jskos",
+    "mapping_to_jskos",
+    "mapping_to_jskos_oracle",
+    "path_to_jskos_oracle",
+]
+
+
+def mapping_set_to_jskos(
+    mappings: list[SemanticMapping], converter: curies.Converter, metadata: MappingSet
+) -> Concept:
+    """Convert a mapping set to JSKOS."""
+    rv = Concept(
+        identifier=[metadata.id],
+        license=[Concept(uri=metadata.license)],
+        mappings=[mapping_to_jskos(mapping, converter) for mapping in mappings],
+    )
+    return rv
+
+
+def mapping_to_jskos(mapping: SemanticMapping, converter: curies.Converter) -> jskos.Mapping:
+    """Convert a mapping to JSKOS."""
+    _r = partial(converter.expand_reference, strict=True)
+
+    return jskos.Mapping.model_validate(
+        {
+            "type": [_r(mapping.predicate)],
+            "from": Concept(member_set=[Concept(uri=_r(mapping.subject))]),
+            "to": Concept(member_set=[Concept(uri=_r(mapping.object))]),
+            "justification": _r(mapping.justification),
+        }
+    )
+
+
+def mapping_to_jskos_oracle(mapping: SemanticMapping, metadata, converter):
+    """Convert a mapping to JSKOS using sssom-js."""
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td).joinpath("example.sssom.tsv")
+        sssom_pydantic.write(
+            [mapping],
+            path,
+            metadata=metadata,
+            converter=converter,
+        )
+        return path_to_jskos_oracle(path)
+
+
+def path_to_jskos_oracle(path: Path) -> jskos.Concept:
+    """Convert SSSOM TSV to JSKOS using sssom-js."""
+    import jskos
+
+    with tempfile.TemporaryDirectory() as td:
+        # Convert the SSSOM TSV to JSKOS using the sssom-js package
+        # on NPM (https://www.npmjs.com/package/sssom-js)
+        jskos_path = Path(td).joinpath("example.sssom.json")
+        result = subprocess.run(  # noqa:S603
+            [  # noqa:S607
+                "npx",
+                "sssom-js",
+                "--from",
+                "tsv",
+                "--to",
+                "jskos",
+                "--output",
+                jskos_path.as_posix(),
+                path.as_posix(),
+            ],
+            stderr=subprocess.PIPE,
+        )
+        # these are concepts, not sure if the KOS class actually
+        # makes any sense
+        text = jskos_path.read_text()
+        if not text:
+            raise ValueError(
+                f"sssom-js produced no output.\n\nstderr: {result.stderr.decode('utf-8')}"
+            )
+
+        return jskos.Concept.model_validate_json(text)

--- a/src/sssom_pydantic/contrib/jskos_export.py
+++ b/src/sssom_pydantic/contrib/jskos_export.py
@@ -91,15 +91,12 @@ def _process_jskos_mapping(
     else:
         comment = None
 
-    # TODO license doesn't get propagated to JSKOS mapping
-
     return SemanticMapping(
         subject=subject,
         predicate=predicate,
         object=obj,
         justification=justification,
         comment=comment,
-        mapping_date=processed_mapping.created,
     )
 
 

--- a/src/sssom_pydantic/contrib/jskos_export.py
+++ b/src/sssom_pydantic/contrib/jskos_export.py
@@ -82,10 +82,9 @@ def _process_jskos_mapping(
     processed_mapping = jskos_mapping.process(converter)
 
     subject = processed_mapping.from_bundle.member_set[0].reference
+    predicate = processed_mapping.type[0]
     obj = processed_mapping.to_bundle.member_set[0].reference
     justification = processed_mapping.justification
-    # TODO why isn't this parsed into a reference upstream?
-    predicate = converter.parse_uri(str(processed_mapping.type[0]), strict=True).to_pydantic()
 
     # `und` means undefined language
     if processed_mapping.note and "und" in processed_mapping.note:

--- a/src/sssom_pydantic/contrib/ndex.py
+++ b/src/sssom_pydantic/contrib/ndex.py
@@ -123,6 +123,8 @@ def _get_prefix_map(
         ) from e
 
     prefixes: set[str] = {prefix for mapping in mappings for prefix in mapping.get_prefixes()}
+    # TODO add prefixes from metadata
+
     # TODO is there a better version of this?
     return {
         prefix: uri_prefix

--- a/src/sssom_pydantic/examples.py
+++ b/src/sssom_pydantic/examples.py
@@ -293,7 +293,7 @@ e6 = ExampleMapping(
 )
 
 e7 = ExampleMapping(
-    description="This example is about when the mapping was done",
+    description="mapping date",
     semantic_mapping=SemanticMapping(
         subject=R1,
         predicate=P1,

--- a/src/sssom_pydantic/io.py
+++ b/src/sssom_pydantic/io.py
@@ -42,6 +42,7 @@ from .process import Hasher, MappingTypeVar, remove_redundant_external, remove_r
 
 __all__ = [
     "Metadata",
+    "ReadType",
     "append",
     "append_unprocessed",
     "lint",
@@ -408,6 +409,10 @@ def _clean_row(row: Mapping[str, str | list[str]]) -> Row:
     return rv
 
 
+#: The result of reading and processing a SSSOM TSV file
+ReadType: TypeAlias = tuple[list[SemanticMapping], Converter, MappingSet]
+
+
 def read(
     path_or_url: str | Path,
     *,
@@ -418,7 +423,7 @@ def read(
     progress_kwargs: dict[str, Any] | None = None,
     record_predicate: RecordPredicate | None = None,
     semantic_mapping_predicate: SemanticMappingPredicate | None = None,
-) -> tuple[list[SemanticMapping], Converter, MappingSet]:
+) -> ReadType:
     """Read and process SSSOM from TSV."""
     with read_iterable(
         path_or_url=path_or_url,

--- a/tests/test_contrib/test_jskos.py
+++ b/tests/test_contrib/test_jskos.py
@@ -8,7 +8,6 @@ from tests.cases import TEST_CONVERTER, TEST_METADATA
 
 JSKOS_IMPLEMENTED = {
     "comment",
-    "mapping date",
 }
 
 

--- a/tests/test_contrib/test_jskos.py
+++ b/tests/test_contrib/test_jskos.py
@@ -2,74 +2,19 @@
 
 import importlib.util
 import unittest
-from typing import TYPE_CHECKING
 
-from curies import Converter, Reference
-from curies.vocabulary import exact_match, manual_mapping_curation
-from pydantic import BaseModel
-
-from sssom_pydantic import SemanticMapping
 from sssom_pydantic.examples import EXAMPLES
 from tests.cases import TEST_CONVERTER, TEST_METADATA
-
-if TYPE_CHECKING:
-    pass
 
 
 @unittest.skipUnless(importlib.util.find_spec("jskos"), reason="requires JSKOS")
 class TestJSKOSExport(unittest.TestCase):
     """Test JSKOS export."""
 
-    def assert_model_equal(self, expected: BaseModel, actual: BaseModel) -> None:
-        """Assert two models are equal."""
-        self.assertEqual(
-            expected.model_dump(exclude_none=True, exclude_unset=True),
-            actual.model_dump(exclude_unset=True, exclude_none=True),
-        )
-
-    def test_jskos(self) -> None:
-        """Test JSKOS export."""
-        from jskos import Concept
-
-        from sssom_pydantic.contrib.jskos_export import mapping_set_to_jskos
-
-        converter = Converter.from_prefix_map(
-            {
-                "skos": "http://www.w3.org/2004/02/skos/core#",
-                "x": "https://example.org/",
-                "semapv": "https://w3id.org/semapv/vocab/",
-            }
-        )
-        license_uri = "https://creativecommons.org/licenses/by/4.0/"
-        mapping = SemanticMapping(
-            subject=Reference(prefix="x", identifier="1"),
-            predicate=exact_match,
-            object=Reference(prefix="x", identifier="1"),
-            justification=manual_mapping_curation,
-        )
-        expected_jskos_record = {
-            "license": [{"uri": license_uri}],
-            "uri": TEST_METADATA.mapping_set_id,
-            "mappings": [
-                {
-                    "type": ["http://www.w3.org/2004/02/skos/core#exactMatch"],
-                    "from": {"memberSet": [{"uri": "http://example.org/1"}]},
-                    "to": {"memberSet": [{"uri": "http://example.org/2"}]},
-                    "justification": "https://w3id.org/semapv/vocab/ManualMappingCuration",
-                }
-            ],
-        }
-        expected = Concept.model_validate(expected_jskos_record)
-        self.assert_model_equal(
-            expected, mapping_set_to_jskos([mapping], converter, TEST_METADATA.process(converter))
-        )
-
-    def test_all_jskos(self) -> None:
-        """Test converting examples to JSKOS then back."""
-        from sssom_pydantic.contrib.jskos_export import mapping_to_jskos_oracle
+    def text_example_output(self) -> None:
+        """Test that all SSSOM examples can be converted to JSKOS."""
+        from sssom_pydantic.contrib.jskos_export import to_jskos
 
         for example in EXAMPLES:
             with self.subTest(desc=example.description):
-                mapping_to_jskos_oracle(
-                    example.semantic_mapping, metadata=TEST_METADATA, converter=TEST_CONVERTER
-                )
+                to_jskos(example.semantic_mapping, converter=TEST_CONVERTER, metadata=TEST_METADATA)

--- a/tests/test_contrib/test_jskos.py
+++ b/tests/test_contrib/test_jskos.py
@@ -11,7 +11,7 @@ from tests.cases import TEST_CONVERTER, TEST_METADATA
 class TestJSKOSExport(unittest.TestCase):
     """Test JSKOS export."""
 
-    def text_example_output(self) -> None:
+    def test_examples(self) -> None:
         """Test that all SSSOM examples can be converted to JSKOS."""
         from sssom_pydantic.contrib.jskos_export import from_jskos, to_jskos
 
@@ -20,10 +20,9 @@ class TestJSKOSExport(unittest.TestCase):
                 concept = to_jskos(
                     example.semantic_mapping, converter=TEST_CONVERTER, metadata=TEST_METADATA
                 )
-                mappings, _, _ = from_jskos(concept)
-                self.assertEqual(1, len(mappings))
+                mappings = from_jskos(concept, TEST_CONVERTER)
                 self.assertEqual(
-                    example.semantic_mapping,
-                    mappings[0],
+                    [example.semantic_mapping],
+                    mappings,
                     msg="reconstitution failed",
                 )

--- a/tests/test_contrib/test_jskos.py
+++ b/tests/test_contrib/test_jskos.py
@@ -13,8 +13,17 @@ class TestJSKOSExport(unittest.TestCase):
 
     def text_example_output(self) -> None:
         """Test that all SSSOM examples can be converted to JSKOS."""
-        from sssom_pydantic.contrib.jskos_export import to_jskos
+        from sssom_pydantic.contrib.jskos_export import from_jskos, to_jskos
 
         for example in EXAMPLES:
             with self.subTest(desc=example.description):
-                to_jskos(example.semantic_mapping, converter=TEST_CONVERTER, metadata=TEST_METADATA)
+                concept = to_jskos(
+                    example.semantic_mapping, converter=TEST_CONVERTER, metadata=TEST_METADATA
+                )
+                mappings, _, _ = from_jskos(concept)
+                self.assertEqual(1, len(mappings))
+                self.assertEqual(
+                    example.semantic_mapping,
+                    mappings[0],
+                    msg="reconstitution failed",
+                )

--- a/tests/test_contrib/test_jskos.py
+++ b/tests/test_contrib/test_jskos.py
@@ -6,6 +6,11 @@ import unittest
 from sssom_pydantic.examples import EXAMPLES
 from tests.cases import TEST_CONVERTER, TEST_METADATA
 
+JSKOS_IMPLEMENTED = {
+    "comment",
+    "mapping date",
+}
+
 
 @unittest.skipUnless(importlib.util.find_spec("jskos"), reason="requires JSKOS")
 class TestJSKOSExport(unittest.TestCase):
@@ -20,9 +25,16 @@ class TestJSKOSExport(unittest.TestCase):
                 concept = to_jskos(
                     example.semantic_mapping, converter=TEST_CONVERTER, metadata=TEST_METADATA
                 )
+                if example.description not in JSKOS_IMPLEMENTED:
+                    # some parts of SSSOM aren't represented in JSKOS
+                    # yet, or don't get exported from sssom-js, so skip
+                    # ones that aren't explicitly working already
+                    continue
                 mappings = from_jskos(concept, TEST_CONVERTER)
+                self.assertEqual(1, len(mappings))
                 self.assertEqual(
-                    [example.semantic_mapping],
-                    mappings,
-                    msg="reconstitution failed",
+                    example.semantic_mapping.model_dump(exclude_none=True, exclude_unset=True),
+                    mappings[0].model_dump(exclude_none=True, exclude_unset=True),
+                    msg=f"reconstitution failed\n\n"
+                    f"{concept.model_dump_json(indent=2, exclude_none=True, exclude_unset=True)}",
                 )

--- a/tests/test_contrib/test_jskos.py
+++ b/tests/test_contrib/test_jskos.py
@@ -1,0 +1,75 @@
+"""Test JSKOS export."""
+
+import importlib.util
+import unittest
+from typing import TYPE_CHECKING
+
+from curies import Converter, Reference
+from curies.vocabulary import exact_match, manual_mapping_curation
+from pydantic import BaseModel
+
+from sssom_pydantic import SemanticMapping
+from sssom_pydantic.examples import EXAMPLES
+from tests.cases import TEST_CONVERTER, TEST_METADATA
+
+if TYPE_CHECKING:
+    pass
+
+
+@unittest.skipUnless(importlib.util.find_spec("jskos"), reason="requires JSKOS")
+class TestJSKOSExport(unittest.TestCase):
+    """Test JSKOS export."""
+
+    def assert_model_equal(self, expected: BaseModel, actual: BaseModel) -> None:
+        """Assert two models are equal."""
+        self.assertEqual(
+            expected.model_dump(exclude_none=True, exclude_unset=True),
+            actual.model_dump(exclude_unset=True, exclude_none=True),
+        )
+
+    def test_jskos(self) -> None:
+        """Test JSKOS export."""
+        from jskos import Concept
+
+        from sssom_pydantic.contrib.jskos_export import mapping_set_to_jskos
+
+        converter = Converter.from_prefix_map(
+            {
+                "skos": "http://www.w3.org/2004/02/skos/core#",
+                "x": "https://example.org/",
+                "semapv": "https://w3id.org/semapv/vocab/",
+            }
+        )
+        license_uri = "https://creativecommons.org/licenses/by/4.0/"
+        mapping = SemanticMapping(
+            subject=Reference(prefix="x", identifier="1"),
+            predicate=exact_match,
+            object=Reference(prefix="x", identifier="1"),
+            justification=manual_mapping_curation,
+        )
+        expected_jskos_record = {
+            "license": [{"uri": license_uri}],
+            "uri": TEST_METADATA.mapping_set_id,
+            "mappings": [
+                {
+                    "type": ["http://www.w3.org/2004/02/skos/core#exactMatch"],
+                    "from": {"memberSet": [{"uri": "http://example.org/1"}]},
+                    "to": {"memberSet": [{"uri": "http://example.org/2"}]},
+                    "justification": "https://w3id.org/semapv/vocab/ManualMappingCuration",
+                }
+            ],
+        }
+        expected = Concept.model_validate(expected_jskos_record)
+        self.assert_model_equal(
+            expected, mapping_set_to_jskos([mapping], converter, TEST_METADATA.process(converter))
+        )
+
+    def test_all_jskos(self) -> None:
+        """Test converting examples to JSKOS then back."""
+        from sssom_pydantic.contrib.jskos_export import mapping_to_jskos_oracle
+
+        for example in EXAMPLES:
+            with self.subTest(desc=example.description):
+                mapping_to_jskos_oracle(
+                    example.semantic_mapping, metadata=TEST_METADATA, converter=TEST_CONVERTER
+                )

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ extras =
     database
     fastapi
     wikidata
+    jskos
 
 [testenv:coverage-clean]
 description = Remove testing coverage artifacts.


### PR DESCRIPTION
This PR adds an exporter from SSSOM to JSKOS that wraps the https://gbv.github.io/sssom-js (and calls it in a subprocess).

I tried to make an initial importer, but sssom-js does not yet implement a TSV writer (see https://github.com/gbv/sssom-js/issues/5). Therefore, I implemented only the simplest, lossy importer. I want to defer to Jakob's implementation since JSKOS is still in development.

Despite that, I tried to implement an object model in https://github.com/cthoyt/jskos. I think that ultimately, there are a few things that make it difficult to work with JSKOS - most importantly, the [class hierarchy](https://gbv.github.io/jskos/#fig-types) does not match up with how Pydantic parses things - specifically, pydantic can not narrow down a Python type hierarchy based on what data is available. This means that even in some of the examples, like [example 2](https://gbv.github.io/jskos/#lst-ranks), where a "item" is used in a slot that's defined as taking a resource, that Pydantic fails to understand it should validate based on the subclass. Pydantic has a notion of a "discriminator" field for this, which _almost_ matches up to how the `type` field is used in JSKOS, but it's not enough
