### PR TITLE
Add SSSOM to Wikidata mapping

### DIFF
--- a/docs/source/contrib.rst
+++ b/docs/source/contrib.rst
@@ -2,3 +2,5 @@ Contrib
 =======
 
 .. automodapi:: sssom_pydantic.contrib.ontoportal
+
+.. automodapi:: sssom_pydantic.contrib.wikidata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ typing = [
     "sqlmodel",
     "fastapi",
     "wikidata-client",
+    "ndex2",
 ]
 docs-lint = [
     { include-group = "docs" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ typing = [
     "types-requests",
     "sqlmodel",
     "fastapi",
+    "wikidata-client",
 ]
 docs-lint = [
     { include-group = "docs" },
@@ -129,6 +130,9 @@ database = [
 ]
 fastapi = [
     "fastapi",
+]
+wikidata = [
+    "wikidata-client",
 ]
 
 # See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,8 @@ fastapi = [
 ]
 wikidata = [
     "wikidata-client",
+    "quickstatements_client",
+    "bioregistry",
 ]
 
 # See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

--- a/src/sssom_pydantic/contrib/ndex.py
+++ b/src/sssom_pydantic/contrib/ndex.py
@@ -124,4 +124,8 @@ def _get_prefix_map(
 
     prefixes: set[str] = {prefix for mapping in mappings for prefix in mapping.get_prefixes()}
     # TODO is there a better version of this?
-    return {prefix: bioregistry.get_uri_prefix(prefix) for prefix in prefixes}
+    return {
+        prefix: uri_prefix
+        for prefix in prefixes
+        if (uri_prefix := bioregistry.get_uri_prefix(prefix))
+    }

--- a/src/sssom_pydantic/contrib/wikidata.py
+++ b/src/sssom_pydantic/contrib/wikidata.py
@@ -1,10 +1,36 @@
-"""Upload from SSSOM to Wikidata with Quickstatements v2.
+"""Implements between semantic mappings in SSSOM and Wikidata.
 
-The [Simple Standard for Sharing Ontology Mappings (SSSOM)](github.com/mapping-commons/sssom)
-supports encoding equivalents, exact matches, cross-references, and other kinds of semantic
-mappings in a simple, tabular format.
+Wikidata encodes semantic mappings in two ways:
 
-Original proposal here: https://doi.org/10.5281/zenodo.17662905
+1. Using the `exact match (P2888) <https://www.wikidata.org/wiki/Property:P2888>`_
+   property with a URI as the object. For example, `cell wall (Q128700)
+   <https://www.wikidata.org/wiki/Q128700>`_ maps to the Gene Ontology (GO) term for
+   `cell wall <https://purl.obolibrary.org/obo/GO_0005618>`_ by its URI
+   ``http://purl.obolibrary.org/obo/GO_0005618``.
+2. Using semantic space-specific properties (e.g. `P683
+   <https://www.wikidata.org/wiki/Property:P683>`_ for ChEBI) with local unique
+   identifiers as the object. For example, `acetic acid (Q47512)
+   <https://www.wikidata.org/wiki/Q47512>`_ maps to the ChEBI term for `acetic acid
+   <https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:15366>`_ using the `P683
+   <https://www.wikidata.org/wiki/Property:P683>`_ property for ChEBI and local unique
+   identifier for acetic acid (within ChEBI) ``15366``.
+
+Wikidata has a data structure that enables annotating qualifiers onto triples.
+Therefore, other parts of semantic mappings modeled in SSSOM can be ported:
+
+1. Authors and reviewers can be mapped from ORCiD identifiers to Wikidata identifiers,
+   then encoded using the `S50 <https://www.wikidata.org/wiki/Property:P50>`_ and `S4032
+   <https://www.wikidata.org/wiki/Property:P4032>`_ properties, respectively
+2. A SKOS-flavored mapping predicate (i.e., exact, narrow, broad, close, related) can be
+   encoded using the `S4390 <https://www.wikidata.org/wiki/Property:P4390>`_ property
+3. The publication date can be encoded using the `S577
+   <https://www.wikidata.org/wiki/Property:P577>`_ property
+4. The license can be mapped from text to a Wikidata identifier, then encoded using the
+   `S275 <https://www.wikidata.org/wiki/Property:P275>`_ property
+
+Note that properties that normally start with a ``P`` when used in triples are changed
+to start with an ``S`` when used as qualifiers. Other fields in SSSOM could potentially
+be mapped to Wikidata later.
 """
 
 from __future__ import annotations

--- a/src/sssom_pydantic/contrib/wikidata.py
+++ b/src/sssom_pydantic/contrib/wikidata.py
@@ -39,30 +39,39 @@ X = TypeVar("X")
 Y = TypeVar("Y")
 
 
-def read_to_quickstatements_tab(path_or_url: str | Path, **kwargs: Any) -> None:
+def read_to_quickstatements_tab(
+    path_or_url: str | Path, *, read_kwargs: dict[str, Any] | None = None, **kwargs: Any
+) -> None:
     """Read an SSSOM file and open the Quickstatements v2 uploader with the web browser."""
-    mappings, converter, metadata = read(path_or_url, **kwargs)
-    open_quickstatements_tab(mappings, converter, metadata)
+    mappings, converter, metadata = read(path_or_url, **(read_kwargs or {}))
+    open_quickstatements_tab(mappings, converter, metadata, **kwargs)
 
 
 def open_quickstatements_tab(
-    mappings: list[SemanticMapping], converter: curies.Converter, metadata: MappingSet
+    mappings: list[SemanticMapping],
+    converter: curies.Converter,
+    metadata: MappingSet,
+    **kwargs: Any,
 ) -> None:
     """Create a QuickStatements tab from mappings."""
-    lines = get_quickstatements_lines(mappings, converter, metadata)
+    lines = get_quickstatements_lines(mappings, converter, metadata, **kwargs)
     quickstatements_client.lines_to_new_tab(lines)
 
 
-def read_to_quickstatements_lines(path_or_url: str | Path, **kwargs: Any) -> list[Line]:
+def read_to_quickstatements_lines(
+    path_or_url: str | Path, *, read_kwargs: dict[str, Any] | None = None, **kwargs: Any
+) -> list[Line]:
     """Read an SSSOM file and get QuickStatements v2 lines."""
-    mappings, converter, metadata = read(path_or_url, **kwargs)
-    return get_quickstatements_lines(mappings, converter, metadata)
+    mappings, converter, metadata = read(path_or_url, **(read_kwargs or {}))
+    return get_quickstatements_lines(mappings, converter, metadata, **kwargs)
 
 
 def get_quickstatements_lines(
     mappings: list[SemanticMapping],
     converter: curies.Converter,
     mapping_set: MappingSet,
+    *,
+    # the following are passable in case of caching
     wikidata_id_to_references: dict[str, set[curies.Reference]] | None = None,
     wikidata_id_to_exact: dict[str, set[curies.Reference]] | None = None,
     orcid_to_wikidata: dict[str, str] | None = None,

--- a/src/sssom_pydantic/contrib/wikidata.py
+++ b/src/sssom_pydantic/contrib/wikidata.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 __all__ = [
     "get_quickstatements_lines",
     "open_quickstatements_tab",
+    "read_to_quickstatements_lines",
+    "read_to_quickstatements_tab",
 ]
 
 X = TypeVar("X")
@@ -48,6 +50,12 @@ def open_quickstatements_tab(
     """Create a QuickStatements tab from mappings."""
     lines = get_quickstatements_lines(mappings, converter, metadata)
     quickstatements_client.lines_to_new_tab(lines)
+
+
+def read_to_quickstatements_lines(path_or_url: str | Path, **kwargs: Any) -> list[Line]:
+    """Read an SSSOM file and get QuickStatements v2 lines."""
+    mappings, converter, metadata = read(path_or_url, **kwargs)
+    return get_quickstatements_lines(mappings, converter, metadata)
 
 
 def get_quickstatements_lines(

--- a/src/sssom_pydantic/contrib/wikidata.py
+++ b/src/sssom_pydantic/contrib/wikidata.py
@@ -26,28 +26,11 @@ from sssom_pydantic import MappingSet, SemanticMapping
 
 __all__ = [
     "get_quickstatements_lines",
-    "get_quickstatements_lines_from_msdf",
     "open_quickstatements_tab",
-    "open_quickstatements_tab_from_msdf",
 ]
 
 X = TypeVar("X")
 Y = TypeVar("Y")
-
-
-def open_quickstatements_tab_from_msdf(
-    mappings: list[SemanticMapping], converter: curies.Converter, metadata: MappingSet
-) -> None:
-    """Create a QuickStatements tab from mappings."""
-    lines = get_quickstatements_lines_from_msdf(mappings, converter, metadata)
-    quickstatements_client.lines_to_new_tab(lines)
-
-
-def get_quickstatements_lines_from_msdf(
-    mappings: list[SemanticMapping], converter: curies.Converter, metadata: MappingSet
-) -> list[Line]:
-    """Get lines for QuickStatements that can be used to upload SSSOM to Wikidata."""
-    return get_quickstatements_lines(mappings, converter, metadata)
 
 
 def open_quickstatements_tab(

--- a/src/sssom_pydantic/contrib/wikidata.py
+++ b/src/sssom_pydantic/contrib/wikidata.py
@@ -108,7 +108,7 @@ def get_quickstatements_lines(
     if orcid_to_wikidata is None:
         orcid_to_wikidata = _get_orcid_to_wikidata(mappings)
 
-    lines = []
+    lines: list[Line] = []
     for mapping in mappings:
         if wikidata_property_id := prefix_to_wikidata.get(mapping.object.prefix):
             if mapping.object in wikidata_id_to_references.get(mapping.subject.identifier, set()):
@@ -213,7 +213,7 @@ SKOS_TO_WIKIDATA: dict[curies.Reference, str] = {
 def _get_mapping_qualifiers(
     mapping: SemanticMapping, orcid_to_wikidata: dict[str, str]
 ) -> list[Qualifier]:
-    rv = []
+    rv: list[Qualifier] = []
 
     # see https://www.wikidata.org/wiki/Property:S275
     if wikidata_license_id := _get_wikidata_license(mapping.license):

--- a/src/sssom_pydantic/contrib/wikidata.py
+++ b/src/sssom_pydantic/contrib/wikidata.py
@@ -3,20 +3,22 @@
 The [Simple Standard for Sharing Ontology Mappings (SSSOM)](github.com/mapping-commons/sssom)
 supports encoding equivalents, exact matches, cross-references, and other kinds of semantic
 mappings in a simple, tabular format.
+
+Original proposal here: https://doi.org/10.5281/zenodo.17662905
 """
 
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Collection
 from textwrap import dedent
-from typing import Any
+from typing import TypeVar
 
 import bioregistry
 import curies
-import pandas as pd
 import quickstatements_client
 import wikidata_client
-from curies.dataframe import get_df_unique_prefixes
+from curies import Converter
 from curies.vocabulary import exact_match
 from quickstatements_client import Line, Qualifier, TextLine, TextQualifier
 
@@ -28,6 +30,9 @@ __all__ = [
     "open_quickstatements_tab",
     "open_quickstatements_tab_from_msdf",
 ]
+
+X = TypeVar("X")
+Y = TypeVar("Y")
 
 
 def open_quickstatements_tab_from_msdf(
@@ -54,7 +59,7 @@ def open_quickstatements_tab(
 
 
 def get_quickstatements_lines(
-    mappings: list[SemanticMapping], converter: curies.Converter, metadata: MappingSet
+    mappings: list[SemanticMapping], converter: curies.Converter, mapping_set: MappingSet
 ) -> list[Line]:
     """Get lines for QuickStatements that can be used to upload SSSOM to Wikidata."""
     mappings = [
@@ -63,97 +68,114 @@ def get_quickstatements_lines(
         if mapping.subject.prefix == "wikidata" and mapping.predicate == exact_match
     ]
 
+    # construct a list of qualifiers that apply to all mappings in the
+    # mapping set, such as the mapping set ID, creators, etc.
     mapping_set_qualifiers = [
         # this sets the "reference URL" to the mapping set ID
-        TextQualifier(predicate="S854", target=metadata["mapping_set_id"]),
+        TextQualifier(predicate="S854", target=mapping_set.id),
         # could also add more metadata here
     ]
 
+    # Get the mapping from Bioregistry prefixes to Wikidata prefixes,
+    # e.g., `chebi` maps to `P683`
     prefix_to_wikidata = bioregistry.get_registry_map("wikidata")
 
-    wikidata_ids = df["wikidata_id"].unique().tolist()
+    # This makes a mapping from the prefixes appearing in mappings to
+    # Wikidata properties. For example, mappings whose objects use
+    # ChEBI get mapped to P683
+    object_prefix_to_wikidata: dict[str, str | None] = {
+        mapping.object.prefix: prefix_to_wikidata.get(mapping.object.prefix) for mapping in mappings
+    }
+
+    wikidata_ids: set[str] = {mapping.subject.identifier for mapping in mappings}
 
     wikidata_id_to_references = _get_wikidata_to_property_matches(
-        wikidata_ids, df, converter, prefix_to_wikidata
+        wikidata_ids, object_prefix_to_wikidata
     )
 
-    wikidata_id_to_exact = _get_wikidata_to_exact_matches(wikidata_ids)
+    wikidata_id_to_exact = _get_wikidata_to_exact_matches(wikidata_ids, converter)
 
-    lines: list[Line] = []
-    for _, row in df.iterrows():
-        subject = row["wikidata_id"]
-        object_curie = row["object_id"]
-        object_reference = converter.parse_curie(object_curie, strict=True)
+    wikidata_id_to_references = _combine(wikidata_id_to_references, wikidata_id_to_exact)
 
-        wikidata_prop = prefix_to_wikidata.get(object_reference.prefix)
+    # filter out all mappings that can already be found on wikidata
+    mappings = [
+        mapping
+        for mapping in mappings
+        if mapping.object not in wikidata_id_to_references.get(mapping.subject.identifier, set())
+    ]
+
+    lines = []
+    for mapping in mappings:
+        wikidata_prop = prefix_to_wikidata.get(mapping.object.prefix)
         if wikidata_prop:
-            existing_references = wikidata_id_to_references.get(subject, set())
-            if object_reference not in existing_references:
-                line = TextLine(
-                    subject=subject,
-                    predicate=wikidata_prop,
-                    target=object_reference.identifier,
-                    qualifiers=[*mapping_set_qualifiers, *_get_mapping_qualifiers(row)],
-                )
-                lines.append(line)
+            line = TextLine(
+                subject=mapping.subject.identifier,
+                predicate=wikidata_prop,
+                target=mapping.object.identifier,
+                qualifiers=[*mapping_set_qualifiers, *_get_mapping_qualifiers(mapping)],
+            )
+            lines.append(line)
         else:
-            object_uri = converter.expand_reference(object_reference, strict=True)
-            existing_uris = wikidata_id_to_exact.get(subject, set())
-            if object_uri not in existing_uris:
-                line = TextLine(
-                    subject=subject,
-                    predicate="P2888",  # exact match
-                    target=object_uri,
-                    qualifiers=[*mapping_set_qualifiers, *_get_mapping_qualifiers(row)],
-                )
-                lines.append(line)
-
+            object_uri = converter.expand_reference(mapping.object, strict=True)
+            line = TextLine(
+                subject=mapping.subject.identifier,
+                predicate="P2888",  # exact match
+                target=object_uri,
+                qualifiers=[*mapping_set_qualifiers, *_get_mapping_qualifiers(mapping)],
+            )
+            lines.append(line)
     return lines
 
 
 def _get_wikidata_to_property_matches(
-    wikidata_ids: list[str],
-    df: pd.DataFrame,
-    converter: curies.Converter,
-    prefix_to_wikidata: dict[str, str] | None = None,
+    wikidata_ids: Collection[str],
+    prefix_to_wikidata: dict[str, str | None],
 ) -> dict[str, set[curies.Reference]]:
-    if prefix_to_wikidata is None:
-        prefix_to_wikidata = bioregistry.get_registry_map("wikidata")
-
-    values = _values(wikidata_ids)
+    values = _values_for_sparql(wikidata_ids)
     rv: defaultdict[str, set[curies.Reference]] = defaultdict(set)
-    for prefix in get_df_unique_prefixes(
-        df, column="object_id", converter=converter, validate=True
-    ):
-        if wdp := prefix_to_wikidata.get(prefix):
-            sparql = dedent(f"""\
-                SELECT ?s ?o WHERE {{
-                    VALUES ?s {{ {values} }}
-                    ?s wdt:{wdp} ?o .
-                }}
-            """)
-            for m in wikidata_client.query(sparql):
-                rv[m["s"]].add(curies.ReferenceTuple(prefix, m["o"]))
 
+    for prefix, wikidata_property_id in prefix_to_wikidata.items():
+        if wikidata_property_id is None:
+            continue
+        sparql = dedent(f"""\
+            SELECT ?s ?o WHERE {{
+                VALUES ?s {{ {values} }}
+                ?s wdt:{wikidata_property_id} ?o .
+            }}
+        """)
+        for record in wikidata_client.query(sparql):
+            rv[record["s"]].add(curies.Reference(prefix=prefix, identifier=record["o"]))
     return dict(rv)
 
 
-def _get_wikidata_to_exact_matches(wikidata_ids: list[str]) -> dict[str, set[str]]:
+def _get_wikidata_to_exact_matches(
+    wikidata_ids: Collection[str], converter: Converter
+) -> dict[str, set[curies.Reference]]:
+    # P2888 is "exact match", see https://www.wikidata.org/wiki/Property:P2888
     sparql = dedent(f"""\
         SELECT ?s ?p ?o WHERE {{
-            VALUES ?s {{ {_values(wikidata_ids)} }}
+            VALUES ?s {{ {_values_for_sparql(wikidata_ids)} }}
             ?s wdt:P2888 ?o .
         }}
     """)
-    rv: defaultdict[str, set[str]] = defaultdict(set)
+    rv: defaultdict[str, set[curies.Reference]] = defaultdict(set)
     for m in wikidata_client.query(sparql):
-        rv[m["s"]].add(m["o"])
+        if reference := converter.parse(m["o"]):
+            rv[m["s"]].add(reference.to_pydantic())
     return dict(rv)
 
 
-def _values(wikidata_ids: list[str]) -> str:
-    return " ".join("wd:" + x for x in wikidata_ids)
+def _combine(*args: dict[X, set[Y]]) -> dict[X, set[Y]]:
+    rv = defaultdict(set)
+    for d in args:
+        for k, values in d.items():
+            rv[k].update(values)
+    return dict(rv)
 
 
-def _get_mapping_qualifiers(mapping: dict[str, Any]) -> list[Qualifier]:
+def _values_for_sparql(wikidata_ids: Collection[str]) -> str:
+    return " ".join("wd:" + x for x in sorted(wikidata_ids))
+
+
+def _get_mapping_qualifiers(mapping: SemanticMapping) -> list[Qualifier]:
     return []

--- a/src/sssom_pydantic/contrib/wikidata.py
+++ b/src/sssom_pydantic/contrib/wikidata.py
@@ -1,0 +1,159 @@
+"""Upload from SSSOM to Wikidata with Quickstatements v2.
+
+The [Simple Standard for Sharing Ontology Mappings (SSSOM)](github.com/mapping-commons/sssom)
+supports encoding equivalents, exact matches, cross-references, and other kinds of semantic
+mappings in a simple, tabular format.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from textwrap import dedent
+from typing import Any
+
+import bioregistry
+import curies
+import pandas as pd
+import quickstatements_client
+import wikidata_client
+from curies.dataframe import get_df_unique_prefixes
+from curies.vocabulary import exact_match
+from quickstatements_client import Line, Qualifier, TextLine, TextQualifier
+
+from sssom_pydantic import MappingSet, SemanticMapping
+
+__all__ = [
+    "get_quickstatements_lines",
+    "get_quickstatements_lines_from_msdf",
+    "open_quickstatements_tab",
+    "open_quickstatements_tab_from_msdf",
+]
+
+
+def open_quickstatements_tab_from_msdf(
+    mappings: list[SemanticMapping], converter: curies.Converter, metadata: MappingSet
+) -> None:
+    """Create a QuickStatements tab from mappings."""
+    lines = get_quickstatements_lines_from_msdf(mappings, converter, metadata)
+    quickstatements_client.lines_to_new_tab(lines)
+
+
+def get_quickstatements_lines_from_msdf(
+    mappings: list[SemanticMapping], converter: curies.Converter, metadata: MappingSet
+) -> list[Line]:
+    """Get lines for QuickStatements that can be used to upload SSSOM to Wikidata."""
+    return get_quickstatements_lines(mappings, converter, metadata)
+
+
+def open_quickstatements_tab(
+    mappings: list[SemanticMapping], converter: curies.Converter, metadata: MappingSet
+) -> None:
+    """Create a QuickStatements tab from mappings."""
+    lines = get_quickstatements_lines(mappings, converter, metadata)
+    quickstatements_client.lines_to_new_tab(lines)
+
+
+def get_quickstatements_lines(
+    mappings: list[SemanticMapping], converter: curies.Converter, metadata: MappingSet
+) -> list[Line]:
+    """Get lines for QuickStatements that can be used to upload SSSOM to Wikidata."""
+    mappings = [
+        mapping
+        for mapping in mappings
+        if mapping.subject.prefix == "wikidata" and mapping.predicate == exact_match
+    ]
+
+    mapping_set_qualifiers = [
+        # this sets the "reference URL" to the mapping set ID
+        TextQualifier(predicate="S854", target=metadata["mapping_set_id"]),
+        # could also add more metadata here
+    ]
+
+    prefix_to_wikidata = bioregistry.get_registry_map("wikidata")
+
+    wikidata_ids = df["wikidata_id"].unique().tolist()
+
+    wikidata_id_to_references = _get_wikidata_to_property_matches(
+        wikidata_ids, df, converter, prefix_to_wikidata
+    )
+
+    wikidata_id_to_exact = _get_wikidata_to_exact_matches(wikidata_ids)
+
+    lines: list[Line] = []
+    for _, row in df.iterrows():
+        subject = row["wikidata_id"]
+        object_curie = row["object_id"]
+        object_reference = converter.parse_curie(object_curie, strict=True)
+
+        wikidata_prop = prefix_to_wikidata.get(object_reference.prefix)
+        if wikidata_prop:
+            existing_references = wikidata_id_to_references.get(subject, set())
+            if object_reference not in existing_references:
+                line = TextLine(
+                    subject=subject,
+                    predicate=wikidata_prop,
+                    target=object_reference.identifier,
+                    qualifiers=[*mapping_set_qualifiers, *_get_mapping_qualifiers(row)],
+                )
+                lines.append(line)
+        else:
+            object_uri = converter.expand_reference(object_reference, strict=True)
+            existing_uris = wikidata_id_to_exact.get(subject, set())
+            if object_uri not in existing_uris:
+                line = TextLine(
+                    subject=subject,
+                    predicate="P2888",  # exact match
+                    target=object_uri,
+                    qualifiers=[*mapping_set_qualifiers, *_get_mapping_qualifiers(row)],
+                )
+                lines.append(line)
+
+    return lines
+
+
+def _get_wikidata_to_property_matches(
+    wikidata_ids: list[str],
+    df: pd.DataFrame,
+    converter: curies.Converter,
+    prefix_to_wikidata: dict[str, str] | None = None,
+) -> dict[str, set[curies.Reference]]:
+    if prefix_to_wikidata is None:
+        prefix_to_wikidata = bioregistry.get_registry_map("wikidata")
+
+    values = _values(wikidata_ids)
+    rv: defaultdict[str, set[curies.Reference]] = defaultdict(set)
+    for prefix in get_df_unique_prefixes(
+        df, column="object_id", converter=converter, validate=True
+    ):
+        if wdp := prefix_to_wikidata.get(prefix):
+            sparql = dedent(f"""\
+                SELECT ?s ?o WHERE {{
+                    VALUES ?s {{ {values} }}
+                    ?s wdt:{wdp} ?o .
+                }}
+            """)
+            for m in wikidata_client.query(sparql):
+                rv[m["s"]].add(curies.ReferenceTuple(prefix, m["o"]))
+
+    return dict(rv)
+
+
+def _get_wikidata_to_exact_matches(wikidata_ids: list[str]) -> dict[str, set[str]]:
+    sparql = dedent(f"""\
+        SELECT ?s ?p ?o WHERE {{
+            VALUES ?s {{ {_values(wikidata_ids)} }}
+            ?s wdt:P2888 ?o .
+        }}
+    """)
+    rv: defaultdict[str, set[str]] = defaultdict(set)
+    for m in wikidata_client.query(sparql):
+        rv[m["s"]].add(m["o"])
+    return dict(rv)
+
+
+def _values(wikidata_ids: list[str]) -> str:
+    return " ".join("wd:" + x for x in wikidata_ids)
+
+
+def _get_mapping_qualifiers(mapping: dict[str, Any]) -> list[Qualifier]:
+    return []

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -17,7 +17,9 @@ __all__ = [
     "R1",
     "R2",
     "TEST_CONVERTER",
+    "TEST_MAPPING_SET",
     "TEST_MAPPING_SET_ID",
+    "TEST_METADATA",
     "TEST_METADATA_W_PREFIX_MAP",
     "TEST_PREFIX_MAP",
     "_m",
@@ -75,6 +77,7 @@ TEST_METADATA = MappingSetRecord(
     mapping_set_id=TEST_MAPPING_SET_ID,
     license="spdx:cc0-1.0",
 )
+TEST_MAPPING_SET = TEST_METADATA.process(TEST_CONVERTER)
 TEST_METADATA_W_PREFIX_MAP = MappingSetRecord(
     curie_map=TEST_PREFIX_MAP,
     mapping_set_id=TEST_MAPPING_SET_ID,

--- a/tests/test_contrib/test_wikidata.py
+++ b/tests/test_contrib/test_wikidata.py
@@ -1,0 +1,43 @@
+"""Test Wikidata conversion."""
+
+import unittest
+
+from curies import Reference
+from curies.vocabulary import exact_match, manual_mapping_curation
+from quickstatements_client import EntityQualifier, TextLine, TextQualifier
+
+from sssom_pydantic import SemanticMapping
+from sssom_pydantic.contrib.wikidata import get_quickstatements_lines
+from tests.cases import TEST_CONVERTER, TEST_MAPPING_SET, TEST_MAPPING_SET_ID
+
+
+class TestWikidata(unittest.TestCase):
+    """Test Wikidata conversion."""
+
+    def test_get_lines(self) -> None:
+        """Test getting lines."""
+        mapping = SemanticMapping(
+            subject=Reference(prefix="wikidata", identifier="Q47512"),
+            predicate=exact_match,
+            object=Reference(prefix="chebi", identifier="15366"),
+            justification=manual_mapping_curation,
+        )
+        lines = get_quickstatements_lines(
+            [mapping],
+            TEST_CONVERTER,
+            TEST_MAPPING_SET,
+            wikidata_id_to_exact={},
+            wikidata_id_to_references={},
+            orcid_to_wikidata={},
+        )
+        self.assertEqual(1, len(lines))
+        expected = TextLine(
+            subject="Q47512",
+            predicate="P683",
+            target="15366",
+            qualifiers=[
+                TextQualifier(predicate="S854", target=TEST_MAPPING_SET_ID),
+                EntityQualifier(predicate="S4390", target="Q39893449"),
+            ],
+        )
+        self.assertEqual(expected, lines[0])

--- a/tests/test_contrib/test_wikidata.py
+++ b/tests/test_contrib/test_wikidata.py
@@ -8,7 +8,10 @@ from curies.vocabulary import charlie, exact_match, manual_mapping_curation
 from quickstatements_client import EntityQualifier, TextLine, TextQualifier
 
 from sssom_pydantic import SemanticMapping
-from sssom_pydantic.contrib.wikidata import get_quickstatements_lines
+from sssom_pydantic.contrib.wikidata import (
+    _get_wikidata_to_property_matches,
+    get_quickstatements_lines,
+)
 from tests.cases import TEST_MAPPING_SET, TEST_MAPPING_SET_ID, TEST_PREFIX_MAP
 
 CHARLIE_WD = "Q47475003"
@@ -89,3 +92,18 @@ class TestWikidata(unittest.TestCase):
                 )
                 self.assertEqual(1, len(lines))
                 self.assertEqual(line, lines[0])
+
+    def test_existing(self) -> None:
+        """Test looking up existing mappings."""
+        res = _get_wikidata_to_property_matches(
+            wikidata_ids=["Q47512"],
+            prefix_to_wikidata={
+                "chebi": "P683",
+                "pdb": "P638",  # exists, but not for this entry
+                "bioregistry": None,  # does not exist
+            },
+        )
+        self.assertEqual(
+            {"Q47512": {Reference(prefix="chebi", identifier="15366")}},
+            res,
+        )

--- a/tests/test_contrib/test_wikidata.py
+++ b/tests/test_contrib/test_wikidata.py
@@ -34,8 +34,8 @@ class TestWikidata(unittest.TestCase):
                     predicate="P683",
                     target="15366",
                     qualifiers=[
-                        TextQualifier(predicate="S854", target=TEST_MAPPING_SET_ID),
                         EntityQualifier(predicate="S4390", target="Q39893449"),
+                        TextQualifier(predicate="S854", target=TEST_MAPPING_SET_ID),
                     ],
                 ),
             ),
@@ -53,10 +53,10 @@ class TestWikidata(unittest.TestCase):
                     predicate="P683",
                     target="15366",
                     qualifiers=[
-                        TextQualifier(predicate="S854", target=TEST_MAPPING_SET_ID),
                         EntityQualifier(predicate="S275", target="Q20007257"),
                         EntityQualifier(predicate="S4390", target="Q39893449"),
                         EntityQualifier(predicate="S50", target=CHARLIE_WD),
+                        TextQualifier(predicate="S854", target=TEST_MAPPING_SET_ID),
                     ],
                 ),
             ),
@@ -72,8 +72,8 @@ class TestWikidata(unittest.TestCase):
                     predicate="P2888",
                     target="https://example.org/chebi",
                     qualifiers=[
-                        TextQualifier(predicate="S854", target=TEST_MAPPING_SET_ID),
                         EntityQualifier(predicate="S4390", target="Q39893449"),
+                        TextQualifier(predicate="S854", target=TEST_MAPPING_SET_ID),
                     ],
                 ),
             ),
@@ -81,8 +81,8 @@ class TestWikidata(unittest.TestCase):
             with self.subTest():
                 lines = get_quickstatements_lines(
                     [mapping],
-                    TEST_CONVERTER,
-                    TEST_MAPPING_SET,
+                    converter=TEST_CONVERTER,
+                    metadata=TEST_MAPPING_SET,
                     wikidata_id_to_exact={},
                     wikidata_id_to_references={},
                     orcid_to_wikidata={charlie.identifier: CHARLIE_WD},

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ extras =
     sssompy
     database
     fastapi
+    wikidata
 
 [testenv:coverage-clean]
 description = Remove testing coverage artifacts.


### PR DESCRIPTION
This PR does the following:

1. proposes a mapping from SSSOM to Wikidata's data model for semantic mappings
2. implements a workflow for converting SSSOM mappings into Quickstatements v2 and uploading them via `quickstatements-client`

This was originally presented at the 4th Ontologies4Chem meeting in Limburg on November 13th, 2025. The corresponding slides are on Zenodo at https://doi.org/10.5281/zenodo.17662905

Requirements:

- [x] https://github.com/cthoyt/wikidata-client/pull/2