### PR TITLE
Get prefixes from metadata

### DIFF
--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -292,6 +292,7 @@ class SemanticMapping(CoreSemanticMapping, SemanticallyStandardizable):
             self.subject_preprocessing,
             self.object_match_field,
             self.object_preprocessing,
+            self.authors,
             self.creators,
             self.reviewers,
             self.curation_rule,

--- a/src/sssom_pydantic/io.py
+++ b/src/sssom_pydantic/io.py
@@ -199,6 +199,11 @@ def write(
     if sort:
         mappings = sorted(mappings)
     records, prefixes = _prepare_records(mappings)
+    if metadata is not None:
+        if converter is None:
+            raise NotImplementedError("when passing non-parsed metadata, need a converter")
+        metadata = _get_mapping_set(metadata, converter)
+        prefixes.update(metadata.get_prefixes())
     write_unprocessed(
         records,
         path=path,
@@ -207,6 +212,16 @@ def write(
         prefixes=prefixes,
         exclude_columns=exclude_columns,
     )
+
+
+def _get_mapping_set(
+    m: MappingSet | Metadata | MappingSetRecord, converter: Converter
+) -> MappingSet:
+    if isinstance(m, MappingSet):
+        return m
+    if isinstance(m, MappingSetRecord):
+        return m.process(converter)
+    raise NotImplementedError
 
 
 def append(

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -78,6 +78,7 @@ TEST_PREFIX_MAP = {
     "biolink": "https://w3id.org/biolink/vocab/",
     "rule": "https://example.org/disease-rule/",
     "bioregistry": "https://bioregistry.io/",
+    "orcid": "https://orcid.org/",
 }
 TEST_CONVERTER = curies.Converter.from_prefix_map(TEST_PREFIX_MAP)
 TEST_METADATA = MappingSetRecord(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -288,6 +288,7 @@ class TestIO(unittest.TestCase):
                 #  chebi: http://purl.obolibrary.org/obo/CHEBI_
                 #  {prefix}: {uri_prefix}
                 #  mesh: http://id.nlm.nih.gov/mesh/
+                #  orcid: https://orcid.org/
                 #  semapv: https://w3id.org/semapv/vocab/
                 #  skos: http://www.w3.org/2004/02/skos/core#
                 #mapping_set_id: {TEST_MAPPING_SET_ID}
@@ -306,6 +307,7 @@ class TestIO(unittest.TestCase):
                 #curie_map:
                 #  chebi: http://purl.obolibrary.org/obo/CHEBI_
                 #  mesh: http://id.nlm.nih.gov/mesh/
+                #  orcid: https://orcid.org/
                 #  semapv: https://w3id.org/semapv/vocab/
                 #  skos: http://www.w3.org/2004/02/skos/core#
                 #mapping_set_id: {TEST_MAPPING_SET_ID}
@@ -324,6 +326,7 @@ class TestIO(unittest.TestCase):
                 #curie_map:
                 #  chebi: http://purl.obolibrary.org/obo/CHEBI_
                 #  mesh: http://id.nlm.nih.gov/mesh/
+                #  orcid: https://orcid.org/
                 #  semapv: https://w3id.org/semapv/vocab/
                 #  skos: http://www.w3.org/2004/02/skos/core#
                 #mapping_set_id: {TEST_MAPPING_SET_ID}


### PR DESCRIPTION
Before, prefixes weren't retrieved from parts of the metadata, e.g., `orcid` from authors. This PR intercepts the metadata and gets these