### PR TITLE
Correctly encode entity types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ license-files = [
 requires-python = ">=3.10"
 dependencies = [
     "pydantic",
-    "curies>=0.12.5",
+    "curies>=0.12.9",
     "pyyaml",
     "pystow",
 ]

--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -16,7 +16,13 @@ from curies.vocabulary import matching_processes
 from pydantic import AnyUrl, BaseModel, ConfigDict, Field
 from typing_extensions import Self
 
-from .constants import MULTIVALUED, PROPAGATABLE, Row
+from .constants import (
+    ENTITY_TYPE_REFERENCE_TO_LITERAL,
+    MULTIVALUED,
+    PROPAGATABLE,
+    EntityTypeLiteral,
+    Row,
+)
 from .models import Cardinality, Record
 
 __all__ = [
@@ -318,6 +324,9 @@ class SemanticMapping(CoreSemanticMapping, SemanticallyStandardizable):
                 return None
             return x.curie
 
+        def _safe_entity_type(x: Reference | None) -> EntityTypeLiteral | None:
+            return ENTITY_TYPE_REFERENCE_TO_LITERAL[x] if x is not None else None
+
         return Record(
             record_id=_safe_curie(self.record),
             #
@@ -328,12 +337,12 @@ class SemanticMapping(CoreSemanticMapping, SemanticallyStandardizable):
             subject_preprocessing=_safe_curies(self.subject_preprocessing),
             subject_source=_safe_curie(self.subject_source),
             subject_source_version=self.subject_source_version,
-            subject_type=_safe_curie(self.subject_type),
+            subject_type=_safe_entity_type(self.subject_type),
             #
             predicate_id=self.predicate.curie,
             predicate_label=self.predicate_name,
             predicate_modifier=self.predicate_modifier,
-            predicate_type=_safe_curie(self.predicate_type),
+            predicate_type=_safe_entity_type(self.predicate_type),
             #
             object_id=self.object.curie,
             object_label=self.object_name,
@@ -342,7 +351,7 @@ class SemanticMapping(CoreSemanticMapping, SemanticallyStandardizable):
             object_preprocessing=_safe_curies(self.object_preprocessing),
             object_source=_safe_curie(self.object_source),
             object_source_version=self.object_source_version,
-            object_type=_safe_curie(self.object_type),
+            object_type=_safe_entity_type(self.object_type),
             #
             mapping_justification=self.justification.curie,
             #

--- a/src/sssom_pydantic/constants.py
+++ b/src/sssom_pydantic/constants.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Literal, TypeAlias
 
 import curies
 from curies import Reference
+from curies import vocabulary as v
 
 __all__ = [
     "BUILTIN_CONVERTER",
     "DEFAULT_PREFIX_MAP",
+    "ENTITY_TYPE_LITERAL_TO_REFERENCE",
+    "ENTITY_TYPE_REFERENCE_TO_LITERAL",
     "MULTIVALUED",
     "PREDICATE_TYPES",
     "PREFIX_MAP_KEY",
     "PROPAGATABLE",
+    "EntityTypeLiteral",
     "Row",
 ]
 
@@ -33,6 +37,42 @@ PREDICATE_TYPES: set[Reference] = {
     Reference(prefix="rdf", identifier="Property"),
     Reference(prefix="sssom", identifier="ComposedEntityExpression"),
 }
+
+#: The literal values for entity type enumeration that goes in the
+#: ``subject_type``, ``predicate_type``, and ``object_type`` fields.
+#: see https://mapping-commons.github.io/sssom/EntityTypeEnum/
+EntityTypeLiteral: TypeAlias = Literal[
+    "owl class",
+    "owl object property",
+    "owl data property",
+    "owl annotation property",
+    "owl named individual",
+    "skos concept",
+    "rdfs resource",
+    "rdfs class",
+    "rdfs literal",
+    "rdfs datatype",
+    "rdf property",
+    "composed entity expression",
+]
+
+#: see https://mapping-commons.github.io/sssom/EntityTypeEnum/
+ENTITY_TYPE_LITERAL_TO_REFERENCE: dict[EntityTypeLiteral, curies.Reference] = {
+    "owl class": v.owl_class,
+    "owl object property": v.owl_object_property,
+    "owl data property": v.owl_data_property,
+    "owl annotation property": v.owl_annotation_property,
+    "owl named individual": v.owl_named_individual,
+    "skos concept": v.skos_concept,
+    "rdfs resource": v.rdfs_resource,
+    "rdfs class": v.rdfs_class,
+    "rdfs literal": v.rdfs_literal,
+    "rdfs datatype": v.rdfs_datatype,
+    "rdf property": v.rdfs_property,
+    "composed entity expression": v.composed_entity_expression,
+}
+
+ENTITY_TYPE_REFERENCE_TO_LITERAL = {v: k for k, v in ENTITY_TYPE_LITERAL_TO_REFERENCE.items()}
 
 #: The set of values that should be propagated
 #: from the frontmatter to all mappings

--- a/src/sssom_pydantic/io.py
+++ b/src/sssom_pydantic/io.py
@@ -30,9 +30,11 @@ from .api import (
 )
 from .constants import (
     BUILTIN_CONVERTER,
+    ENTITY_TYPE_LITERAL_TO_REFERENCE,
     MULTIVALUED,
     PREFIX_MAP_KEY,
     PROPAGATABLE,
+    EntityTypeLiteral,
     Row,
 )
 from .models import Record, RecordPredicate
@@ -131,6 +133,11 @@ def record_to_semantic_mapping(record: Record, converter: curies.Converter) -> S
             return None
         return converter.parse(curie_or_uri, strict=True).to_pydantic()
 
+    def _safe_entity_type(entity_type: EntityTypeLiteral | None) -> Reference | None:
+        if entity_type is None:
+            return None
+        return ENTITY_TYPE_LITERAL_TO_REFERENCE[entity_type]
+
     return SemanticMapping(
         subject=subject,
         predicate=predicate,
@@ -149,14 +156,14 @@ def record_to_semantic_mapping(record: Record, converter: curies.Converter) -> S
         subject_preprocessing=_parse_curies_or_uris(record.subject_preprocessing),
         subject_source=_parse_curie_or_uri(record.subject_source),
         subject_source_version=record.subject_source_version,
-        subject_type=record.subject_type,
-        predicate_type=_parse_curie_or_uri(record.predicate_type),
+        subject_type=_safe_entity_type(record.subject_type),
+        predicate_type=_safe_entity_type(record.predicate_type),
         object_category=_parse_curie_or_uri(record.object_category),
         object_match_field=_parse_curies_or_uris(record.object_match_field),
         object_preprocessing=_parse_curies_or_uris(record.object_preprocessing),
         object_source=_parse_curie_or_uri(record.object_source),
         object_source_version=record.object_source_version,
-        object_type=record.subject_type,
+        object_type=_safe_entity_type(record.object_type),
         creators=_parse_curies_or_uris(record.creator_id),
         reviewers=_parse_curies_or_uris(record.reviewer_id),
         publication_date=record.publication_date,

--- a/src/sssom_pydantic/models.py
+++ b/src/sssom_pydantic/models.py
@@ -9,7 +9,7 @@ from typing import Literal, TypeAlias
 from curies.vocabulary import matching_processes
 from pydantic import AnyUrl, BaseModel, ConfigDict, Field
 
-from .constants import PREDICATE_TYPES
+from .constants import EntityTypeLiteral
 
 __all__ = [
     "Cardinality",
@@ -37,16 +37,15 @@ class Record(BaseModel):
     subject_preprocessing: list[str] | None = Field(None)
     subject_source: str | None = Field(None)
     subject_source_version: str | None = Field(None)
-    subject_type: str | None = Field(None)
+    subject_type: EntityTypeLiteral | None = Field(
+        None, description="See https://mapping-commons.github.io/sssom/subject_type"
+    )
 
     predicate_id: str = Field(...)
     predicate_label: str | None = Field(None)
     predicate_modifier: Literal["Not"] | None = Field(None)
-    predicate_type: str | None = Field(
-        None,
-        examples=[x.curie for x in PREDICATE_TYPES],
-        description="See https://mapping-commons.github.io/sssom/predicate_type/. "
-        "Values allowed are from https://mapping-commons.github.io/sssom/EntityTypeEnum/",
+    predicate_type: EntityTypeLiteral | None = Field(
+        None, description="See https://mapping-commons.github.io/sssom/predicate_type"
     )
 
     object_id: str = Field(...)
@@ -56,10 +55,8 @@ class Record(BaseModel):
     object_preprocessing: list[str] | None = Field(None)
     object_source: str | None = Field(None)
     object_source_version: str | None = Field(None)
-    object_type: str | None = Field(
-        None,
-        description="See https://mapping-commons.github.io/sssom/object_type/. "
-        "Values allowed are from https://mapping-commons.github.io/sssom/EntityTypeEnum/",
+    object_type: EntityTypeLiteral | None = Field(
+        None, description="See https://mapping-commons.github.io/sssom/object_type"
     )
 
     mapping_justification: str = Field(..., examples=[p.curie for p in matching_processes])


### PR DESCRIPTION
it turns out that `subject_type`, `predicate_type`, and `object_type` need to be encoded with SSSOM-specific literal strings instead of using the corresponding CURIEs. While this is itself bonkers, this PR updates parsing to follow the standard until SSSOM can be fixed