### PR TITLE
Add default mapping hash

### DIFF
--- a/src/sssom_pydantic/database/sql_database.py
+++ b/src/sssom_pydantic/database/sql_database.py
@@ -224,7 +224,7 @@ class SemanticMappingDatabase(SemanticMappingRepository):
         self,
         *,
         engine: Engine,
-        semantic_mapping_hash: SemanticMappingHash,
+        semantic_mapping_hash: SemanticMappingHash | None = None,
         session_cls: type[Session] | None = None,
         converter: curies.Converter,
     ) -> None:
@@ -248,7 +248,7 @@ class SemanticMappingDatabase(SemanticMappingRepository):
         cls,
         *,
         connection: str,
-        semantic_mapping_hash: SemanticMappingHash,
+        semantic_mapping_hash: SemanticMappingHash | None = None,
         session_cls: type[Session] | None = None,
         converter: curies.Converter,
     ) -> Self:
@@ -264,7 +264,7 @@ class SemanticMappingDatabase(SemanticMappingRepository):
     def memory(
         cls,
         *,
-        semantic_mapping_hash: SemanticMappingHash,
+        semantic_mapping_hash: SemanticMappingHash | None = None,
         session_cls: type[Session] | None = None,
         converter: curies.Converter,
     ) -> Self:

--- a/src/sssom_pydantic/web.py
+++ b/src/sssom_pydantic/web.py
@@ -10,7 +10,7 @@ from curies.vocabulary import charlie, exact_match, manual_mapping_curation
 from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException, Path, Request
 
 from sssom_pydantic import SemanticMapping
-from sssom_pydantic.api import SemanticMappingHash, mapping_hash_v1
+from sssom_pydantic.api import SemanticMappingHash
 from sssom_pydantic.database import SemanticMappingRepository
 from sssom_pydantic.examples import EXAMPLE_MAPPINGS, R1, R2
 from sssom_pydantic.process import MARKS, Mark
@@ -152,7 +152,7 @@ def get_app(
             converter = bioregistry.get_default_converter()
 
         repository = SemanticMappingDatabase.memory(
-            semantic_mapping_hash=semantic_mapping_hash or mapping_hash_v1,
+            semantic_mapping_hash=semantic_mapping_hash,
             converter=converter,
         )
 


### PR DESCRIPTION
This PR removes the need to explicitly define the mapping hash, since right now, there isn't a good alternative.

After https://github.com/mapping-commons/sssom/issues/436 is finalized, there will be an officially mandated hash function, and this argument will be deprecated.