### PR TITLE
Fix ordering of Record

### DIFF
--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -213,6 +213,25 @@ def _join(references: list[Reference] | None) -> list[str] | None:
     return [r.curie for r in references]
 
 
+FORWARDS_MAPS = {
+    # get rid of the redundant suffix `_id`
+    "record_id": "record",
+    "subject_id": "subject",
+    "predicate_id": "predicate",
+    "object_id": "object",
+    "reviewer_id": "reviewers",
+    "author_id": "authors",
+    "creator_id": "creators",
+    # get rid of the redundant prefix `mapping_`
+    "mapping_justification": "justification",
+    "mapping_cardinality": "cardinality",
+    "mapping_source": "source",
+    "mapping_provider": "provider",
+}
+
+BACKWARDS_MAPS = {v: k for k, v in FORWARDS_MAPS.items()}
+
+
 class SemanticMapping(CoreSemanticMapping, SemanticallyStandardizable):
     """Represents all fields for SSSOM.."""
 

--- a/src/sssom_pydantic/models.py
+++ b/src/sssom_pydantic/models.py
@@ -17,6 +17,8 @@ __all__ = [
     "RecordPredicate",
 ]
 
+#: Cardinality annotations, which are valid within the scope of a mapping set
+#: but should not be saved as part of a mapping
 Cardinality: TypeAlias = Literal["1:1", "1:n", "n:1", "1:0", "0:1", "n:n", "0:0"]
 
 
@@ -33,46 +35,44 @@ class Record(BaseModel):
     subject_id: str = Field(...)
     subject_label: str | None = Field(None)
     subject_category: str | None = Field(None)
-    subject_match_field: list[str] | None = Field(None)
-    subject_preprocessing: list[str] | None = Field(None)
-    subject_source: str | None = Field(None)
-    subject_source_version: str | None = Field(None)
-    subject_type: EntityTypeLiteral | None = Field(
-        None, description="See https://mapping-commons.github.io/sssom/subject_type"
-    )
-
     predicate_id: str = Field(...)
     predicate_label: str | None = Field(None)
     predicate_modifier: Literal["Not"] | None = Field(None)
-    predicate_type: EntityTypeLiteral | None = Field(
-        None, description="See https://mapping-commons.github.io/sssom/predicate_type"
-    )
-
     object_id: str = Field(...)
     object_label: str | None = Field(None)
     object_category: str | None = Field(None)
-    object_match_field: list[str] | None = Field(None)
-    object_preprocessing: list[str] | None = Field(None)
-    object_source: str | None = Field(None)
-    object_source_version: str | None = Field(None)
+    mapping_justification: str = Field(..., examples=[p.curie for p in matching_processes])
+    author_id: list[str] | None = Field(None)
+    author_label: list[str] | None = Field(None)
+    reviewer_id: list[str] | None = Field(None)
+    reviewer_label: list[str] | None = Field(None)
+    creator_id: list[str] | None = Field(None)
+    creator_label: list[str] | None = Field(None)
+    license: str | None = Field(None)
+    subject_type: EntityTypeLiteral | None = Field(
+        None, description="See https://mapping-commons.github.io/sssom/subject_type"
+    )
+    subject_source: str | None = Field(None)
+    subject_source_version: str | None = Field(None)
     object_type: EntityTypeLiteral | None = Field(
         None, description="See https://mapping-commons.github.io/sssom/object_type"
     )
-
-    mapping_justification: str = Field(..., examples=[p.curie for p in matching_processes])
-
-    author_id: list[str] | None = Field(None)
-    author_label: list[str] | None = Field(None)
-    creator_id: list[str] | None = Field(None)
-    creator_label: list[str] | None = Field(None)
-    reviewer_id: list[str] | None = Field(None)
-    reviewer_label: list[str] | None = Field(None)
-
-    publication_date: datetime.date | None = Field(None)
+    object_source: str | None = Field(None)
+    object_source_version: str | None = Field(None)
+    predicate_type: EntityTypeLiteral | None = Field(
+        None, description="See https://mapping-commons.github.io/sssom/predicate_type"
+    )
+    mapping_provider: AnyUrl | None = Field(None)
+    mapping_source: str | None = Field(None)
+    #: see https://mapping-commons.github.io/sssom/MappingCardinalityEnum/
+    mapping_cardinality: Cardinality | None = Field(None)
+    cardinality_scope: list[str] | None = Field(None)
+    mapping_tool: str | None = Field(None)
+    mapping_tool_id: str | None = Field(None)
+    mapping_tool_version: str | None = Field(None)
     mapping_date: datetime.date | None = Field(None)
+    publication_date: datetime.date | None = Field(None)
     review_date: datetime.date | None = Field(None)
-
-    comment: str | None = Field(None)
     confidence: float | None = Field(
         None,
         ge=0.0,
@@ -101,26 +101,20 @@ class Record(BaseModel):
         function if a knowledge graph embedding model was used ot generate a mapping prediction.
         """,
     )
-    reviewer_agreement: float | None = Field(None, ge=-1.0, le=1.0)
+    reviewer_agreement: float | None = Field(None, ge=-1.0, le=1.0, examples=[-1.0, 0.0, 1.0])
     curation_rule: list[str] | None = Field(None)
     curation_rule_text: list[str] | None = Field(None)
-    issue_tracker_item: str | None = Field(None)
-    license: str | None = Field(None)
-
-    #: see https://mapping-commons.github.io/sssom/MappingCardinalityEnum/
-    mapping_cardinality: Cardinality | None = Field(None)
-    cardinality_scope: list[str] | None = Field(None)
-    mapping_provider: AnyUrl | None = Field(None)
-    mapping_source: str | None = Field(None)
-    mapping_tool: str | None = Field(None)
-    mapping_tool_id: str | None = Field(None)
-    mapping_tool_version: str | None = Field(None)
+    subject_match_field: list[str] | None = Field(None)
+    object_match_field: list[str] | None = Field(None)
     match_string: list[str] | None = Field(None)
-
-    other: str | None = Field(None)
-    see_also: list[str] | None = Field(None)
-    similarity_measure: str | None = Field(None)
+    subject_preprocessing: list[str] | None = Field(None)
+    object_preprocessing: list[str] | None = Field(None)
     similarity_score: float | None = Field(None, ge=0.0, le=1.0)
+    similarity_measure: str | None = Field(None)
+    see_also: list[str] | None = Field(None)
+    issue_tracker_item: str | None = Field(None)
+    other: str | None = Field(None)
+    comment: str | None = Field(None)
 
 
 #: A predicate for a record

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -16,7 +16,7 @@ import pystow
 from curies import Reference
 from pydantic import AnyUrl
 
-from sssom_pydantic import MappingSetRecord, Record, SemanticMapping
+from sssom_pydantic.api import BACKWARDS_MAPS, FORWARDS_MAPS, MappingSetRecord, SemanticMapping
 from sssom_pydantic.constants import (
     MAPPING_SET_SLOTS,
     MAPPING_SET_SLOTS_SKIP,
@@ -24,7 +24,7 @@ from sssom_pydantic.constants import (
     PROPAGATABLE,
 )
 from sssom_pydantic.examples import EXAMPLES
-from sssom_pydantic.models import Cardinality
+from sssom_pydantic.models import Cardinality, Record
 
 if TYPE_CHECKING:
     import linkml_runtime
@@ -114,21 +114,6 @@ class TestSchema(unittest.TestCase):
 
     def test_value_types(self) -> None:
         """Test that values with entity references are type annotated as references."""
-        maps = {
-            # get rid of the redundant suffix `_id`
-            "record_id": "record",
-            "subject_id": "subject",
-            "predicate_id": "predicate",
-            "object_id": "object",
-            "reviewer_id": "reviewers",
-            "author_id": "authors",
-            "creator_id": "creators",
-            # get rid of the redundant prefix `mapping_`
-            "mapping_justification": "justification",
-            "mapping_cardinality": "cardinality",
-            "mapping_source": "source",
-            "mapping_provider": "provider",
-        }
         skips = {
             # skip these because they're mapped in a custom way
             "mapping_tool_id",
@@ -152,7 +137,7 @@ class TestSchema(unittest.TestCase):
             if slot in skips:
                 continue
             with self.subTest(slot=slot):
-                annotation = SemanticMapping.model_fields[maps.get(slot, slot)].annotation
+                annotation = SemanticMapping.model_fields[FORWARDS_MAPS.get(slot, slot)].annotation
                 multivalued = slot in MULTIVALUED
                 match self.view.get_slot(slot).range:
                     case "EntityReference":
@@ -284,6 +269,18 @@ class TestSchema(unittest.TestCase):
                             f"missing handling for slot {slot} with range "
                             f"{self.view.get_slot(slot).range}"
                         )
+
+    def test_order(self) -> None:
+        """Test the slots are in the order specified by the SSSOM schema."""
+        self.assertEqual(
+            self.view.get_class("mapping").slots,
+            list(Record.model_fields),
+        )
+
+    def test_model_mapping(self) -> None:
+        """Test processed models can be mapped back into the other."""
+        for field in SemanticMapping.model_fields:
+            self.assertIn(BACKWARDS_MAPS.get(field, field), Record.model_fields)
 
 
 class TestExampleCompleteness(unittest.TestCase):


### PR DESCRIPTION
The order of the fields in the Record model did not match the SSSOM schema definition, which will be important for making a canonical hash. This PR adds a test to make sure they're in sync.

This will have the effect that previously "linted" SSSOM files might change now 