### PR TITLE
Remove name from curation

### DIFF
--- a/src/sssom_pydantic/process.py
+++ b/src/sssom_pydantic/process.py
@@ -241,7 +241,7 @@ def curate(
         update["mapping_date"] = date
 
     if mark in semantic_mapping_scopes:
-        update["predicate"] = semantic_mapping_scopes[mark]
+        update["predicate"] = semantic_mapping_scopes[mark].pair.to_pydantic()
     elif mark == "incorrect":
         update["predicate_modifier"] = "Not"
     elif mark == "correct":

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -48,6 +48,9 @@ class TestProcess(unittest.TestCase):
             actual.model_dump(exclude_none=True, exclude_unset=True),
             msg=msg,
         )
+        self.assertEqual(expected.subject_name, actual.subject_name)
+        self.assertEqual(expected.predicate_name, actual.predicate_name)
+        self.assertEqual(expected.object_name, actual.object_name)
 
     def test_curate(self) -> None:
         """Test curation."""
@@ -98,7 +101,7 @@ class TestProcess(unittest.TestCase):
                     "EXACT",
                     SemanticMapping(
                         subject=R1,
-                        predicate=exact_match,
+                        predicate=exact_match.pair.to_pydantic(),
                         object=R2,
                         justification=manual_mapping_curation,
                         authors=[author],
@@ -109,7 +112,7 @@ class TestProcess(unittest.TestCase):
                     "BROAD",
                     SemanticMapping(
                         subject=R1,
-                        predicate=broad_match,
+                        predicate=broad_match.pair.to_pydantic(),
                         object=R2,
                         justification=manual_mapping_curation,
                         authors=[author],
@@ -120,7 +123,7 @@ class TestProcess(unittest.TestCase):
                     "NARROW",
                     SemanticMapping(
                         subject=R1,
-                        predicate=narrow_match,
+                        predicate=narrow_match.pair.to_pydantic(),
                         object=R2,
                         justification=manual_mapping_curation,
                         authors=[author],

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -18,7 +18,6 @@ from curies.vocabulary import (
 from curies.vocabulary import (
     manual_mapping_curation as manual,
 )
-from pydantic import BaseModel
 
 from sssom_pydantic import SemanticMapping
 from sssom_pydantic.api import NOT
@@ -40,7 +39,7 @@ class TestProcess(unittest.TestCase):
     """Test processing."""
 
     def assert_model_equal(
-        self, expected: BaseModel, actual: BaseModel, msg: str | None = None
+        self, expected: SemanticMapping, actual: SemanticMapping, msg: str | None = None
     ) -> None:
         """Assert two models are equal."""
         self.assertEqual(


### PR DESCRIPTION
The curate function no longer injects unwanted predicate labels