### PR TITLE
Improve handling mapping set creators

### DIFF
--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -488,6 +488,14 @@ SemanticMappingPredicate: TypeAlias = Callable[[SemanticMapping], bool]
 SemanticMappingHash: TypeAlias = Callable[[SemanticMapping, curies.Converter], Reference]
 
 
+def _upgrade_str(x: str | list[str] | None) -> list[str] | None:
+    if x is None:
+        return None
+    elif isinstance(x, str):
+        return [x]
+    return x
+
+
 class MappingSetRecord(BaseModel):
     """Represents a mapping set, readily serializable for usage in SSSOM TSV."""
 
@@ -512,7 +520,7 @@ class MappingSetRecord(BaseModel):
     license: AnyUrl | None = Field(None)
     issue_tracker: AnyUrl | None = Field(None)
     extension_definitions: list[ExtensionDefinitionRecord] | None = Field(None)
-    creator_id: list[str] | None = None
+    creator_id: Annotated[list[str] | None, BeforeValidator(_upgrade_str)] = None
     creator_label: list[str] | None = None
 
     # propagatable slots
@@ -557,7 +565,7 @@ class MappingSetRecord(BaseModel):
             extension_definitions=list(self.extension_definitions)
             if self.extension_definitions
             else None,
-            creators=[converter.parse_curie(c, strict=True) for c in self.creator_id]
+            creators=[converter.parse_curie(c, strict=True).to_pydantic() for c in self.creator_id]
             if self.creator_id
             else None,
             creator_label=self.creator_label,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,10 +6,27 @@ from curies import NamableReference, Reference
 from curies.vocabulary import unspecified_matching_process
 
 from sssom_pydantic import SemanticMapping
+from sssom_pydantic.api import MappingSetRecord
 
 
 class TestModel(unittest.TestCase):
     """Tests for the Pydantic model."""
+
+    def test_creator_id(self) -> None:
+        """Test a non-list creator gets properly upgraded."""
+        x = {
+            "mapping_set_id": "https://example.org/test.tsv",
+            "creator_id": "orcid:1111-1111-1111-1111",
+        }
+        model = MappingSetRecord.model_validate(x)
+        self.assertIsInstance(model.creator_id, list)
+
+        x = {
+            "mapping_set_id": "https://example.org/test.tsv",
+            "creator_id": ["orcid:1111-1111-1111-1111"],
+        }
+        model = MappingSetRecord.model_validate(x)
+        self.assertIsInstance(model.creator_id, list)
 
     def test_upgrade(self) -> None:
         """Test before-validation rule on subject, predicate, and object."""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -21,11 +21,11 @@ class TestModel(unittest.TestCase):
         model = MappingSetRecord.model_validate(x)
         self.assertIsInstance(model.creator_id, list)
 
-        x = {
+        x2 = {
             "mapping_set_id": "https://example.org/test.tsv",
             "creator_id": ["orcid:1111-1111-1111-1111"],
         }
-        model = MappingSetRecord.model_validate(x)
+        model = MappingSetRecord.model_validate(x2)
         self.assertIsInstance(model.creator_id, list)
 
     def test_upgrade(self) -> None:


### PR DESCRIPTION
This PR does two things:

1. fixes a bug where a creator isn't properly shuttled from a ReferenceTuple to a Reference
2. adds a quality of life improvement for incorrect SSSOM documents, where the creator was given as a string instead of a list. Something about being permissive on inputs, but strict on outputs.