### PR TITLE
Recover from bad value in `other`

### DIFF
--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -476,7 +476,7 @@ def _dict_to_other(x: dict[str, str]) -> str:
     return OTHER_PRIMARY_SEP.join(f"{k}{OTHER_SECONDARY_SEP}{v}" for k, v in sorted(x.items()))
 
 
-def _other_to_dict(x: str, line_number: int | None = None) -> dict[str, str] | None:
+def _other_to_dict(x: str, *, line_number: int | None = None) -> dict[str, str] | None:
     return (
         dict(
             pair
@@ -487,7 +487,7 @@ def _other_to_dict(x: str, line_number: int | None = None) -> dict[str, str] | N
     )
 
 
-def _split_key_value(s: str, line_number: int | None = None) -> tuple[str, str] | None:
+def _split_key_value(s: str, *, line_number: int | None = None) -> tuple[str, str] | None:
     try:
         left, right = s.split(OTHER_SECONDARY_SEP)
     except ValueError:
@@ -576,7 +576,7 @@ class MappingSetRecord(BaseModel):
     subject_source_version: str | None = None
     subject_type: str | None = None
 
-    def process(self, converter: curies.Converter, line_number: int | None = None) -> MappingSet:
+    def process(self, converter: curies.Converter, *, line_number: int | None = None) -> MappingSet:
         """Get a mapping set."""
         return MappingSet(
             id=self.mapping_set_id,

--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import functools
+import logging
 from collections.abc import Callable
 from typing import Annotated, Any, Literal, TypeAlias
 
@@ -472,12 +473,23 @@ def _dict_to_other(x: dict[str, str]) -> str:
     return OTHER_PRIMARY_SEP.join(f"{k}{OTHER_SECONDARY_SEP}{v}" for k, v in sorted(x.items()))
 
 
-def _other_to_dict(x: str) -> dict[str, str]:
-    return dict(_xx(y) for y in x.split(OTHER_PRIMARY_SEP))
+def _other_to_dict(x: str) -> dict[str, str] | None:
+    return (
+        dict(
+            pair
+            for key_value in x.split(OTHER_PRIMARY_SEP)
+            if (pair := _split_key_value(key_value))
+        )
+        or None
+    )
 
 
-def _xx(s: str) -> tuple[str, str]:
-    left, right = s.split(OTHER_SECONDARY_SEP)
+def _split_key_value(s: str) -> tuple[str, str] | None:
+    try:
+        left, right = s.split(OTHER_SECONDARY_SEP)
+    except ValueError:
+        logging.warning("invalid value for `other`: %s", s)
+        return None
     return left, right
 
 

--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -476,22 +476,25 @@ def _dict_to_other(x: dict[str, str]) -> str:
     return OTHER_PRIMARY_SEP.join(f"{k}{OTHER_SECONDARY_SEP}{v}" for k, v in sorted(x.items()))
 
 
-def _other_to_dict(x: str) -> dict[str, str] | None:
+def _other_to_dict(x: str, line_number: int | None = None) -> dict[str, str] | None:
     return (
         dict(
             pair
             for key_value in x.split(OTHER_PRIMARY_SEP)
-            if (pair := _split_key_value(key_value))
+            if (pair := _split_key_value(key_value, line_number=line_number))
         )
         or None
     )
 
 
-def _split_key_value(s: str) -> tuple[str, str] | None:
+def _split_key_value(s: str, line_number: int | None = None) -> tuple[str, str] | None:
     try:
         left, right = s.split(OTHER_SECONDARY_SEP)
     except ValueError:
-        logging.warning("invalid value for `other`: %s", s)
+        if line_number is not None:
+            logging.warning("[line: %d] invalid value for `other`: %s", line_number, s)
+        else:
+            logging.warning("invalid value for `other`: %s", s)
         return None
     return left, right
 
@@ -573,7 +576,7 @@ class MappingSetRecord(BaseModel):
     subject_source_version: str | None = None
     subject_type: str | None = None
 
-    def process(self, converter: curies.Converter) -> MappingSet:
+    def process(self, converter: curies.Converter, line_number: int | None = None) -> MappingSet:
         """Get a mapping set."""
         return MappingSet(
             id=self.mapping_set_id,
@@ -585,7 +588,7 @@ class MappingSetRecord(BaseModel):
             #
             publication_date=self.publication_date,
             see_also=self.see_also,
-            other=_other_to_dict(self.other) if self.other else None,
+            other=_other_to_dict(self.other, line_number=line_number) if self.other else None,
             comment=self.comment,
             sssom_version=self.sssom_version,
             license=self.license,

--- a/src/sssom_pydantic/io.py
+++ b/src/sssom_pydantic/io.py
@@ -94,7 +94,9 @@ def row_to_semantic_mapping(
     return record_to_semantic_mapping(record, converter)
 
 
-def record_to_semantic_mapping(record: Record, converter: curies.Converter) -> SemanticMapping:
+def record_to_semantic_mapping(
+    record: Record, converter: curies.Converter, line_number: int | None = None
+) -> SemanticMapping:
     """Parse a record into a mapping."""
     subject = converter.parse_curie(record.subject_id, strict=True).to_pydantic(
         name=record.subject_label
@@ -180,7 +182,7 @@ def record_to_semantic_mapping(record: Record, converter: curies.Converter) -> S
         provider=record.mapping_provider,
         source=_parse_curie_or_uri(record.mapping_source),
         match_string=record.match_string,
-        other=_other_to_dict(record.other) if record.other else None,
+        other=_other_to_dict(record.other, line_number=line_number) if record.other else None,
         see_also=record.see_also,
         similarity_measure=record.similarity_measure,
         similarity_score=record.similarity_score,
@@ -478,7 +480,9 @@ def read_iterable(
         def _process() -> Iterable[SemanticMapping]:
             for line_number, record in t.records:
                 try:
-                    mapping = record_to_semantic_mapping(record, t.converter)
+                    mapping = record_to_semantic_mapping(
+                        record, t.converter, line_number=line_number
+                    )
                 except ValueError:
                     logger.warning("[line %d] failed to process record: %s", line_number, record)
                     continue

--- a/src/sssom_pydantic/io.py
+++ b/src/sssom_pydantic/io.py
@@ -95,7 +95,7 @@ def row_to_semantic_mapping(
 
 
 def record_to_semantic_mapping(
-    record: Record, converter: curies.Converter, line_number: int | None = None
+    record: Record, converter: curies.Converter, *, line_number: int | None = None
 ) -> SemanticMapping:
     """Parse a record into a mapping."""
     subject = converter.parse_curie(record.subject_id, strict=True).to_pydantic(


### PR DESCRIPTION
There are many records that incorrectly use `other`, e.g., by adding a comma-separated list of PubMed identifier CURIEs.

This PR catches exceptions thrown when being unable to correctly parse, and writes a warning message to STDERR instead.