### PR TITLE
Add additional pre-parsing

### DIFF
--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import functools
+import logging
 from collections.abc import Callable
 from typing import Annotated, Any, Literal, TypeAlias, TypeVar
 
@@ -38,6 +39,9 @@ __all__ = [
     "hash_mapping_to_reference",
     "hash_triple",
 ]
+
+
+logger = logging.getLogger(__name__)
 
 PredicateModifier: TypeAlias = Literal["Not"]
 NOT: PredicateModifier = "Not"
@@ -499,12 +503,14 @@ def _upgrade_list(x: X | list[X] | None) -> list[X] | None:
     return [x]
 
 
-def _fix_relative_url(x: str | AnyUrl) -> AnyUrl:
-    if isinstance(x, AnyUrl):
-        return x
-    if x.startswith("http://") or x.startswith("https://"):
-        return AnyUrl(x)
-    return AnyUrl(f"https://w3id.org/sssom/mapping-set/{x}")
+def _fix_relative_url(s: str | AnyUrl) -> AnyUrl:
+    if isinstance(s, AnyUrl):
+        return s
+    if s.startswith("http://") or s.startswith("https://"):
+        return AnyUrl(s)
+    url = f"https://w3id.org/sssom/mapping-set/{s}"
+    logger.warning("mapping set has non-relative URL: %s. Formatted into %s", s, url)
+    return AnyUrl(url)
 
 
 class MappingSetRecord(BaseModel):

--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 import functools
 from collections.abc import Callable
-from typing import Annotated, Any, Literal, TypeAlias
+from typing import Annotated, Any, Literal, TypeAlias, TypeVar
 
 import curies
 from curies import NamableReference, Reference, Triple
@@ -488,12 +488,23 @@ SemanticMappingPredicate: TypeAlias = Callable[[SemanticMapping], bool]
 SemanticMappingHash: TypeAlias = Callable[[SemanticMapping, curies.Converter], Reference]
 
 
-def _upgrade_str(x: str | list[str] | None) -> list[str] | None:
+X = TypeVar("X")
+
+
+def _upgrade_list(x: X | list[X] | None) -> list[X] | None:
     if x is None:
         return None
-    elif isinstance(x, str):
-        return [x]
-    return x
+    elif isinstance(x, list):
+        return x
+    return [x]
+
+
+def _fix_relative_url(x: str | AnyUrl) -> AnyUrl:
+    if isinstance(x, AnyUrl):
+        return x
+    if x.startswith("http://") or x.startswith("https://"):
+        return AnyUrl(x)
+    return AnyUrl(f"https://w3id.org/sssom/mapping-set/{x}")
 
 
 class MappingSetRecord(BaseModel):
@@ -503,15 +514,15 @@ class MappingSetRecord(BaseModel):
 
     curie_map: dict[str, str] | None = None
 
-    mapping_set_id: AnyUrl = Field(...)
+    mapping_set_id: Annotated[AnyUrl, BeforeValidator(_fix_relative_url)] = Field(...)
     mapping_set_confidence: float | None = Field(None, ge=0.0, le=1.0)
     mapping_set_description: str | None = Field(None)
-    mapping_set_source: list[AnyUrl] | None = Field(None)
+    mapping_set_source: Annotated[list[AnyUrl] | None, BeforeValidator(_upgrade_list)] = Field(None)
     mapping_set_title: str | None = Field(None)
     mapping_set_version: str | None = Field(None)
 
     publication_date: datetime.date | None = Field(None)
-    see_also: list[AnyUrl] | None = Field(None)
+    see_also: Annotated[list[AnyUrl] | None, BeforeValidator(_upgrade_list)] = Field(None)
     other: str | None = Field(None)
     comment: str | None = Field(None)
     sssom_version: str | None = Field(None)
@@ -520,7 +531,7 @@ class MappingSetRecord(BaseModel):
     license: AnyUrl | None = Field(None)
     issue_tracker: AnyUrl | None = Field(None)
     extension_definitions: list[ExtensionDefinitionRecord] | None = Field(None)
-    creator_id: Annotated[list[str] | None, BeforeValidator(_upgrade_str)] = None
+    creator_id: Annotated[list[str] | None, BeforeValidator(_upgrade_list)] = None
     creator_label: list[str] | None = None
 
     # propagatable slots
@@ -619,12 +630,12 @@ class MappingSet(BaseModel):
     version: str | None = Field(None)
 
     publication_date: datetime.date | None = Field(None)
-    see_also: list[str] | None = Field(None)
+    see_also: list[AnyUrl] | None = Field(None)
     other: str | None = Field(None)
     comment: str | None = Field(None)
     sssom_version: str | None = Field(None)
     license: AnyUrl | None = Field(None)
-    issue_tracker: str | None = Field(None)
+    issue_tracker: AnyUrl | None = Field(None)
     extension_definitions: list[ExtensionDefinition] | None = Field(None)
     creators: list[Reference] | None = None
     creator_label: list[str] | None = None

--- a/src/sssom_pydantic/models.py
+++ b/src/sssom_pydantic/models.py
@@ -67,6 +67,7 @@ class Record(BaseModel):
         None, description="See https://mapping-commons.github.io/sssom/predicate_type"
     )
     mapping_provider: AnyUrl | None = Field(None)
+    #: https://mapping-commons.github.io/sssom/mapping_source/
     mapping_source: str | None = Field(None)
     #: see https://mapping-commons.github.io/sssom/MappingCardinalityEnum/
     mapping_cardinality: Cardinality | None = Field(None)

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -212,7 +212,7 @@ class TestSchema(unittest.TestCase):
                 self.assertIn(slot, MappingSetRecord.model_fields)
                 annotation = MappingSetRecord.model_fields[slot].annotation
                 if typing.get_origin(annotation) is typing.Annotated:
-                    annotation = typing.get_args(annotation[0])
+                    annotation = typing.get_args(annotation)[0]
                 multivalued = self.view.get_slot(slot).multivalued
                 match self.view.get_slot(slot).range:
                     case "EntityReference":

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -211,6 +211,8 @@ class TestSchema(unittest.TestCase):
             with self.subTest(slot=slot):
                 self.assertIn(slot, MappingSetRecord.model_fields)
                 annotation = MappingSetRecord.model_fields[slot].annotation
+                if typing.get_origin(annotation) is typing.Annotated:
+                    annotation = typing.get_args(annotation[0])
                 multivalued = self.view.get_slot(slot).multivalued
                 match self.view.get_slot(slot).range:
                     case "EntityReference":
@@ -247,13 +249,13 @@ class TestSchema(unittest.TestCase):
                             self.assertIn(
                                 annotation,
                                 {list[AnyUrl], list[AnyUrl] | None},
-                                msg=f"{slot} should be annotated as a list[str]",
+                                msg=f"\n{slot} should be annotated as a list[AnyUrl]",
                             )
                         else:
                             self.assertIn(
                                 annotation,
                                 {AnyUrl, AnyUrl | None},
-                                msg=f"{slot} should be annotated as a string",
+                                msg=f"{slot} should be annotated as a AnyUrl",
                             )
                     case "double":
                         self.assertIn(


### PR DESCRIPTION
This PR is a follow-up to #99 to add additional quality-of-life improvements to the parser to be more accepting of input in a SSSOM TSV's metadata that isn't quite up to spec.

1. If the `mapping_set_id` isn't a proper URL, prepend something to the beginning
2. If the `mapping_set_source` or `see_also` is a string instead of a list, then make it a list