### PR TITLE
Implement processing functions to support a subsetting workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "pydantic",
-    "curies>=0.13.6",
+    "curies>=0.13.7",
     "pyyaml",
     "pystow>=0.8.6",
     "tqdm",

--- a/src/sssom_pydantic/__init__.py
+++ b/src/sssom_pydantic/__init__.py
@@ -1,6 +1,7 @@
 """Pydantic models for SSSOM."""
 
 from .api import (
+    NOT,
     ExtensionDefinition,
     ExtensionDefinitionRecord,
     MappingSet,
@@ -28,6 +29,7 @@ from .models import Record
 from .process import invert
 
 __all__ = [
+    "NOT",
     "ExtensionDefinition",
     "ExtensionDefinitionRecord",
     "MappingSet",

--- a/src/sssom_pydantic/api.py
+++ b/src/sssom_pydantic/api.py
@@ -6,14 +6,14 @@ import datetime
 import functools
 import logging
 from collections.abc import Callable
-from typing import Annotated, Any, Literal, TypeAlias, TypeVar
+from typing import Annotated, Any, Literal, TypeAlias
 
 import curies
 from curies import NamableReference, Reference, Triple
 from curies.mixins import SemanticallyStandardizable
 from curies.vocabulary import exact_match, matching_processes, unspecified_matching_process
 from pydantic import AnyUrl, BaseModel, BeforeValidator, ConfigDict, Field
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 from .constants import (
     ENTITY_TYPE_REFERENCE_TO_LITERAL,
@@ -500,8 +500,13 @@ def _split_key_value(s: str, *, line_number: int | None = None) -> tuple[str, st
     return left, right
 
 
+#: A type variable bound to a semantic mapping type, to
+#: make it possible to annotate functions that spit out the
+#: same type that goes in
+MappingTypeVar = TypeVar("MappingTypeVar", bound=SemanticMapping, default=SemanticMapping)
+
 #: A predicate for a semantic mapping
-SemanticMappingPredicate: TypeAlias = Callable[[SemanticMapping], bool]
+SemanticMappingPredicate: TypeAlias = Callable[[MappingTypeVar], bool]
 
 #: A function that hashes a semantic mapping into a reference
 SemanticMappingHash: TypeAlias = Callable[[SemanticMapping, curies.Converter], Reference]

--- a/src/sssom_pydantic/io.py
+++ b/src/sssom_pydantic/io.py
@@ -25,6 +25,7 @@ from .api import (
     MappingSet,
     MappingSetRecord,
     MappingTool,
+    MappingTypeVar,
     SemanticMapping,
     SemanticMappingPredicate,
     _other_to_dict,
@@ -40,7 +41,7 @@ from .constants import (
     Row,
 )
 from .models import Record, RecordPredicate
-from .process import Hasher, MappingTypeVar, remove_redundant_external, remove_redundant_internal
+from .process import Hasher, remove_redundant_external, remove_redundant_internal
 
 __all__ = [
     "Metadata",

--- a/src/sssom_pydantic/process.py
+++ b/src/sssom_pydantic/process.py
@@ -28,7 +28,7 @@ from curies.vocabulary import (
     semantic_mapping_scopes,
 )
 
-from .api import SemanticMapping
+from .api import MappingTypeVar, SemanticMapping, SemanticMappingPredicate
 
 if TYPE_CHECKING:
     from _typeshed import SupportsRichComparison
@@ -45,8 +45,11 @@ __all__ = [
     "Mark",
     "curate",
     "estimate_confidence",
+    "exclude_negative",
+    "exclude_unsure",
     "get_canonical_tuple",
     "invert",
+    "invert_by_prefix_pair",
     "publish",
     "remove_redundant_external",
     "remove_redundant_internal",
@@ -56,13 +59,10 @@ __all__ = [
 #: A canonical mapping tuple
 CanonicalMappingTuple: TypeAlias = tuple[str, str, str, str]
 
-#: A type variable bound to a semantic mapping type, to
-#: make it possible to annotate functions that spit out the
-#: same type that goes in
-MappingTypeVar = TypeVar("MappingTypeVar", bound=SemanticMapping)
-
-#: The type used in hashing functions.
-HashTarget = TypeVar("HashTarget")
+#: The type used in hashing functions, which get put into a set.
+#: This is set with ``tuple[str, ...]`` as a default because normally,
+#: The hash function used is :func:`get_canonical_tuple`
+HashTarget = TypeVar("HashTarget", bound=typing.Hashable, default=tuple[str, ...])
 
 #: A function that constructs a hashable object from a semantic mapping
 Hasher: TypeAlias = Callable[[MappingTypeVar], HashTarget]
@@ -344,7 +344,7 @@ for key in SemanticMapping.model_fields:
         EXCHANGABLE_FIELDS.add(key[len("object_") :])
 
 
-def invert(mapping: SemanticMapping) -> SemanticMapping:
+def invert(mapping: MappingTypeVar) -> MappingTypeVar:
     """Invert a mapping.
 
     :param mapping: A semantic mapping record
@@ -528,6 +528,89 @@ def plot2d() -> None:
     fig.colorbar(mesh, ax=ax)
     plt.show()
     plt.savefig("images/reviewer-agreement-aggregation.svg")
+
+
+def exclude_negative(mappings: Iterable[MappingTypeVar]) -> Iterable[MappingTypeVar]:
+    """Exclude negative mappings.
+
+    :param mappings: An iterable of semantic mappings
+
+    :returns: A list of semantic mappings, with all negative mappings excluded
+
+    >>> from sssom_pydantic import SemanticMapping, NOT
+    >>> m1 = SemanticMapping.exact("mesh:C000089", "CHEBI:28646")
+    >>> m2 = SemanticMapping.exact("mesh:C000089", "CHEBI:28647", predicate_modifier=NOT)
+    >>> assert [m1] == list(exclude_negative([m1, m2]))
+    """
+    for mapping in mappings:
+        if mapping.predicate_modifier is None:
+            yield mapping
+
+
+def exclude_unsure(mappings: Iterable[MappingTypeVar]) -> Iterable[MappingTypeVar]:
+    """Exclude usunre mappings.
+
+    :param mappings: An iterable of semantic mappings
+
+    :returns: A list of semantic mappings, with all unsure mappings excluded.
+        Mappings are considered unsure when there's a explicit reviewer agreement of 0.0.
+
+    >>> from sssom_pydantic import SemanticMapping, NOT
+    >>> m1 = SemanticMapping.exact("CHEBI:48552", "MESH:D020926")
+    >>> m2 = SemanticMapping.exact("CHEBI:53227", "MESH:D020959", reviewer_agreement=1.0)
+    >>> m3 = SemanticMapping.exact("CHEBI:82761", "MESH:D023082", reviewer_agreement=0.0)
+    >>> assert [m1, m2] == list(exclude_unsure([m1, m2, m3]))
+    """
+    for mapping in mappings:
+        if mapping.reviewer_agreement != 0.0:
+            yield mapping
+
+
+def invert_by_predicate(
+    mappings: Iterable[MappingTypeVar], predicate: SemanticMappingPredicate
+) -> Iterable[MappingTypeVar]:
+    """Invert based on prefixes.
+
+    :param mappings: An iterable of semantic mappings
+    :param predicate: A predicate function
+
+    :returns: An iterable of semantic mappings, with the correct ones inverted
+    """
+    for mapping in mappings:
+        if predicate(mapping):
+            yield invert(mapping)
+        else:
+            yield mapping
+
+
+def invert_by_prefix_pair(
+    mappings: Iterable[MappingTypeVar], source_prefix: str, target_prefix: str
+) -> Iterable[MappingTypeVar]:
+    """Invert mappings with the given subject and object (SO) prefixes.
+
+    :param mappings: An iterable of semantic mappings
+    :param source_prefix: Invert mappings that have this source prefix
+    :param target_prefix: Invert mappings that have this target prefix
+
+    :returns: An iterable of semantic mappings, with the correct ones inverted
+
+    >>> from curies.vocabulary import mapping_inversion
+    >>> from sssom_pydantic import SemanticMapping, NOT
+    >>> m1 = SemanticMapping.exact("mesh:C000089", "CHEBI:28646")
+    >>> m1_inv = SemanticMapping.exact(
+    ...     "CHEBI:28646", "mesh:C000089", justification=mapping_inversion
+    ... )
+    >>> m2 = SemanticMapping.exact("CHEBI:10001", "mesh:C067604")
+    >>> assert [m1_inv, m2] == list(invert_by_prefix_pair([m1, m2], "mesh", "CHEBI"))
+    """
+    yield from invert_by_predicate(mappings, _so_prefixes(source_prefix, target_prefix))
+
+
+def _so_prefixes(source_prefix: str, target_prefix: str) -> SemanticMappingPredicate:
+    def _func(m: MappingTypeVar) -> bool:
+        return m.subject.prefix == source_prefix and m.object.prefix == target_prefix
+
+    return _func
 
 
 if __name__ == "__main__":

--- a/src/sssom_pydantic/process.py
+++ b/src/sssom_pydantic/process.py
@@ -9,15 +9,7 @@ import statistics
 import typing
 from collections import defaultdict
 from collections.abc import Callable, Collection, Iterable
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    TypeAlias,
-    TypeVar,
-    cast,
-    get_args,
-)
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast, get_args
 
 from curies import Reference
 from curies.vocabulary import (
@@ -27,6 +19,7 @@ from curies.vocabulary import (
     semantic_mapping_inversions,
     semantic_mapping_scopes,
 )
+from typing_extensions import TypeVar
 
 from .api import MappingTypeVar, SemanticMapping, SemanticMappingPredicate
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -20,6 +20,7 @@ from curies.vocabulary import (
 )
 
 from sssom_pydantic import SemanticMapping
+from sssom_pydantic import process as pr
 from sssom_pydantic.api import NOT
 from sssom_pydantic.process import (
     InvalidExistsActionError,
@@ -507,3 +508,25 @@ class TestProcess(cases.MappingTestCaseMixin):
         for i, (expected, initial) in enumerate(pairs, start=1):
             with self.subTest(index=str(i)):
                 self.assert_model_equal(expected, invert(initial))
+
+    def test_exclude_negative(self) -> None:
+        """Test excluding negative mappings."""
+        m1 = SemanticMapping.exact("mesh:C000089", "CHEBI:28646")
+        m2 = SemanticMapping.exact("mesh:C000089", "CHEBI:28647", predicate_modifier=NOT)
+        self.assertEqual([m1], list(pr.exclude_negative([m1, m2])))
+
+    def test_exclude_unsure(self) -> None:
+        """Test excluding unsure mappings."""
+        m1 = SemanticMapping.exact("CHEBI:48552", "MESH:D020926")
+        m2 = SemanticMapping.exact("CHEBI:53227", "MESH:D020959", reviewer_agreement=1.0)
+        m3 = SemanticMapping.exact("CHEBI:82761", "MESH:D023082", reviewer_agreement=0.0)
+        self.assertEqual([m1, m2], list(pr.exclude_unsure([m1, m2, m3])))
+
+    def test_invert_so(self) -> None:
+        """Test inverting mappings with given S/O prefix pairs."""
+        m1 = SemanticMapping.exact("mesh:C000089", "CHEBI:28646")
+        m1_inv = SemanticMapping.exact(
+            "CHEBI:28646", "mesh:C000089", justification=mapping_inversion
+        )
+        m2 = SemanticMapping.exact("CHEBI:10001", "mesh:C067604")
+        self.assertEqual([m1_inv, m2], list(pr.invert_by_prefix_pair([m1, m2], "mesh", "CHEBI")))


### PR DESCRIPTION
After seeing https://github.com/monarch-initiative/monarch-mapping-commons/pull/73, I wanted to provide a more idiomatic way to subset Biomappings (and improve https://github.com/monarch-initiative/monarch-mapping-commons/blob/main/scripts/process_biomappings.py)

In this PR, I add several processing functions to support doing this including functions for:

1. excluding negative mappings
2. excluding unsure mappings (i.e., reviewer agreement == 0.0)
3. inverting a given subject-object prefix pair

Along the way, I came up with additional abstractions for typing