### PR TITLE
Add more control to `sssom_pydantic.write`

### DIFF
--- a/src/sssom_pydantic/io.py
+++ b/src/sssom_pydantic/io.py
@@ -275,7 +275,7 @@ def write(
     if reduce_prefix_map:
         records, prefixes = _prepare_records(mappings)
     else:
-        records = [m.to_record() for m in mappings]
+        records = (m.to_record() for m in mappings)
         prefixes = set()
 
     if metadata is not None:
@@ -318,7 +318,7 @@ def append(
     """Append processed records."""
     records, prefixes = _prepare_records(mappings)
     append_unprocessed(
-        records,
+        list(records),
         path=path,
         metadata=metadata,
         converter=converter,
@@ -327,7 +327,7 @@ def append(
     )
 
 
-def _prepare_records(mappings: Iterable[SemanticMapping]) -> tuple[list[Record], set[str]]:
+def _prepare_records(mappings: Iterable[SemanticMapping]) -> tuple[Iterable[Record], set[str]]:
     records = []
     prefixes: set[str] = set()
     for mapping in mappings:
@@ -369,7 +369,7 @@ def append_unprocessed(
 
 
 def write_unprocessed(
-    records: Sequence[Record],
+    records: Iterable[Record],
     path: str | Path | TextIO,
     *,
     metadata: MappingSet | Metadata | MappingSetRecord | None = None,
@@ -393,6 +393,11 @@ def write_unprocessed(
         than one pass over the mappings
     """
     metadata = _get_metadata(metadata)
+
+    if condense or columns is None:
+        # in this case, we can't stream, since we need to take
+        # one or more passes over the records
+        records = list(records)
 
     if condense:
         condensation = _get_condensation(records)

--- a/src/sssom_pydantic/io.py
+++ b/src/sssom_pydantic/io.py
@@ -236,6 +236,7 @@ def write(
     exclude_columns: Collection[str] | None = None,
     exclude_prefixes: Collection[str] | None = None,
     condense: bool = True,
+    subset_converter: bool = True,
 ) -> None:
     """Write processed records."""
     if exclude_mappings is not None:
@@ -244,7 +245,13 @@ def write(
         mappings = remove_redundant_internal(mappings, key=drop_duplicates_key)
     if sort:
         mappings = sorted(mappings)
-    records, prefixes = _prepare_records(mappings)
+
+    if subset_converter:
+        records, prefixes = _prepare_records(mappings)
+    else:
+        records = [m.to_record() for m in mappings]
+        prefixes = set()
+
     if metadata is not None:
         if converter is None:
             raise NotImplementedError("when passing non-parsed metadata, need a converter")
@@ -257,7 +264,7 @@ def write(
         path=path,
         metadata=metadata,
         converter=converter,
-        prefixes=prefixes,
+        prefixes=prefixes if subset_converter else None,
         columns=columns,
         exclude_columns=exclude_columns,
         condense=condense,

--- a/src/sssom_pydantic/io.py
+++ b/src/sssom_pydantic/io.py
@@ -238,7 +238,33 @@ def write(
     condense: bool = True,
     reduce_prefix_map: bool = True,
 ) -> None:
-    """Write processed records."""
+    """Write semantic mappings as SSSOM TSV.
+
+    :param mappings: an iterable of semantic mappings
+    :param path: the path or file-like object to write to
+    :param metadata: metadata to write to the header of the SSSOM file
+    :param converter: the converter whose internal prefix map will be written in the
+        header of the SSSOM file. If ``reduce_prefix_map`` is ``True``, then only
+        prefixes used in semantic mappings will be written
+    :param exclude_mappings: an iterable of semantic mappings to exclude. If used,
+        streaming writing is not possible.
+    :param exclude_mappings_key: a key function for identifying "redundant" mappings
+    :param drop_duplicates: whether to drop redundant mappings. If used, streaming
+        writing is not possible.
+    :param drop_duplicates_key: a key function for identifying "duplicate" mappings
+    :param sort: Should mappings be sorted? If used, streaming writing is not possible.
+    :param columns: If given, explicitly use these columns instead of inferring which
+        have data in the given semantic mappings. This is required to enable streaming
+        writing.
+    :param exclude_columns: columns to explicitly exclude from writing, whether
+        ``columns`` is given or not
+    :param exclude_prefixes: prefixes to explicitly exclude from writing
+    :param condense: Should fields from mappings be condensed into the SSSOM header?
+        Defaults to ``True``, but must be turned off to enable streaming writing.
+    :param reduce_prefix_map: Should the prefix map be reduced based on prefixes
+        appearing in mappings and the metadata? If used, streaming writing is not
+        possible.
+    """
     if exclude_mappings is not None:
         mappings = remove_redundant_external(mappings, exclude_mappings, key=exclude_mappings_key)
     if drop_duplicates:
@@ -360,11 +386,11 @@ def write_unprocessed(
     :param metadata: metadata to use
     :param converter: converter to use
     :param prefixes: if given, subsets the converter
-    :param columns: explicitly set what columns should be output.
-        Results in taking more than one pass over the mappings
+    :param columns: explicitly set what columns should be output. Results in taking more
+        than one pass over the mappings
     :param exclude_columns: explicitly set what columns should not be output
-    :param condense: condense mappings into mapping set metadata.
-        Results in taking more than one pass over the mappings
+    :param condense: condense mappings into mapping set metadata. Results in taking more
+        than one pass over the mappings
     """
     metadata = _get_metadata(metadata)
 

--- a/src/sssom_pydantic/io.py
+++ b/src/sssom_pydantic/io.py
@@ -236,7 +236,7 @@ def write(
     exclude_columns: Collection[str] | None = None,
     exclude_prefixes: Collection[str] | None = None,
     condense: bool = True,
-    subset_converter: bool = True,
+    reduce_prefix_map: bool = True,
 ) -> None:
     """Write processed records."""
     if exclude_mappings is not None:
@@ -246,7 +246,7 @@ def write(
     if sort:
         mappings = sorted(mappings)
 
-    if subset_converter:
+    if reduce_prefix_map:
         records, prefixes = _prepare_records(mappings)
     else:
         records = [m.to_record() for m in mappings]
@@ -264,7 +264,7 @@ def write(
         path=path,
         metadata=metadata,
         converter=converter,
-        prefixes=prefixes if subset_converter else None,
+        prefixes=prefixes if reduce_prefix_map else None,
         columns=columns,
         exclude_columns=exclude_columns,
         condense=condense,

--- a/src/sssom_pydantic/io.py
+++ b/src/sssom_pydantic/io.py
@@ -232,8 +232,10 @@ def write(
     drop_duplicates: bool = False,
     drop_duplicates_key: Hasher[MappingTypeVar, Y] | None = None,
     sort: bool = False,
+    columns: Sequence[str] | None = None,
     exclude_columns: Collection[str] | None = None,
     exclude_prefixes: Collection[str] | None = None,
+    condense: bool = True,
 ) -> None:
     """Write processed records."""
     if exclude_mappings is not None:
@@ -256,7 +258,9 @@ def write(
         metadata=metadata,
         converter=converter,
         prefixes=prefixes,
+        columns=columns,
         exclude_columns=exclude_columns,
+        condense=condense,
     )
 
 
@@ -267,7 +271,7 @@ def _get_mapping_set(
         return m
     if isinstance(m, MappingSetRecord):
         return m.process(converter)
-    raise NotImplementedError
+    raise NotImplementedError(f"not sure what to do with {type(m)}")
 
 
 def append(
@@ -338,18 +342,33 @@ def write_unprocessed(
     metadata: MappingSet | Metadata | MappingSetRecord | None = None,
     converter: curies.Converter | None = None,
     prefixes: set[str] | None = None,
+    columns: Sequence[str] | None = None,
     exclude_columns: Collection[str] | None = None,
+    condense: bool = True,
 ) -> None:
-    """Write unprocessed records."""
-    columns = _get_columns(records)
+    """Write unprocessed records.
 
+    :param records: records to write
+    :param path: the path to a file or a file-like object to write to
+    :param metadata: metadata to use
+    :param converter: converter to use
+    :param prefixes: if given, subsets the converter
+    :param columns: explicitly set what columns should be output.
+        Results in taking more than one pass over the mappings
+    :param exclude_columns: explicitly set what columns should not be output
+    :param condense: condense mappings into mapping set metadata.
+        Results in taking more than one pass over the mappings
+    """
     metadata = _get_metadata(metadata)
 
-    condensation = _get_condensation(records)
-    for key, value in condensation.items():
-        if key in metadata and metadata[key] != value:
-            logger.warning("mismatch between given metadata and observed. overwriting")
-        metadata[key] = value
+    if condense:
+        condensation = _get_condensation(records)
+        for key, value in condensation.items():
+            if key in metadata and metadata[key] != value:
+                logger.warning("mismatch between given metadata and observed. overwriting")
+            metadata[key] = value
+    else:
+        condensation = {}
 
     converters = []
     if converter is not None:
@@ -367,12 +386,16 @@ def write_unprocessed(
     if bimap := converter.bimap:
         metadata[PREFIX_MAP_KEY] = bimap
 
-    exclude = set(condensation).union(exclude_columns or [])
-    columns = [column for column in columns if column not in exclude]
+    if columns is None:
+        columns = _get_columns(records)
+        exclude = set(condensation).union(exclude_columns or [])
+        columns = [column for column in columns if column not in exclude]
+    else:
+        exclude = None
 
     with safe_open(path, operation="write", representation="text") as file:
         write_metadata(metadata, file)
-        writer = csv.DictWriter(file, columns, delimiter="\t")
+        writer = csv.DictWriter(file, columns, delimiter="\t", extrasaction="ignore")
         writer.writeheader()
         writer.writerows(_unprocess_row(record, exclude=exclude) for record in records)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -509,7 +509,7 @@ class TestIO(cases.MappingTestCaseMixin):
                 subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification	author_id
                 mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration	{AUTHOR.curie}
                 mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration	
-            """),  # noqa:E501
+            """),  # noqa:E501,W291
             path_condensed.read_text(),
             msg="subject/object labels and authors should not be included, "
             "since they were not in the columns list",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -508,7 +508,7 @@ class TestIO(cases.MappingTestCaseMixin):
                 #mapping_set_id: {TEST_MAPPING_SET_ID}
                 subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification	author_id
                 mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration	{AUTHOR.curie}
-                mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration
+                mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration	
             """),  # noqa:E501
             path_condensed.read_text(),
             msg="subject/object labels and authors should not be included, "
@@ -530,7 +530,7 @@ class TestIO(cases.MappingTestCaseMixin):
                 #mapping_set_id: {TEST_MAPPING_SET_ID}
                 subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification	author_id	mapping_date
                 mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration	{AUTHOR.curie}	2026-05-04
-                mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration		2026-05-04	
+                mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration		2026-05-04
             """),  # noqa:E501
             path_uncondensed.read_text(),
             msg="\nskipping condense failed",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import tempfile
 import types
 import typing
@@ -450,4 +451,87 @@ class TestIO(cases.MappingTestCaseMixin):
                 mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration	{a2.curie}
             """),  # noqa:E501
             path.read_text(),
+        )
+
+    def test_write_explicit_columns(self) -> None:
+        """Test writing with exclude."""
+        path = self.directory.joinpath("test.sssom.tsv")
+        metadata = MappingSet(id=TEST_MAPPING_SET_ID)
+        m = _m(authors=[AUTHOR])
+        sssom_pydantic.write(
+            [m],
+            path,
+            converter=TEST_CONVERTER,
+            metadata=metadata,
+            columns=["subject_id", "predicate_id", "object_id", "mapping_justification"],
+        )
+        self.assertEqual(
+            dedent(f"""\
+                #curie_map:
+                #  chebi: http://purl.obolibrary.org/obo/CHEBI_
+                #  mesh: http://id.nlm.nih.gov/mesh/
+                #  orcid: https://orcid.org/
+                #  semapv: https://w3id.org/semapv/vocab/
+                #  skos: http://www.w3.org/2004/02/skos/core#
+                #mapping_set_id: {TEST_MAPPING_SET_ID}
+                subject_id	predicate_id	object_id	mapping_justification
+                mesh:C000089	skos:exactMatch	chebi:28646	semapv:ManualMappingCuration
+            """),
+            path.read_text(),
+            msg="subject/object labels and authors should not be included, "
+            "since they were not in the columns list",
+        )
+
+    def test_toggle_condense(self) -> None:
+        """Test toggling condense."""
+        metadata = MappingSet(id=TEST_MAPPING_SET_ID)
+        date = "2026-05-04"
+        m1 = _m(authors=[AUTHOR], mapping_date=datetime.date.fromisoformat(date))
+        m2 = _m(mapping_date=datetime.date.fromisoformat(date))
+
+        path_condensed = self.directory.joinpath("test.sssom.tsv")
+        sssom_pydantic.write(
+            [m1, m2],
+            path_condensed,
+            converter=TEST_CONVERTER,
+            metadata=metadata,
+        )
+        self.assertEqual(
+            dedent(f"""\
+                #curie_map:
+                #  chebi: http://purl.obolibrary.org/obo/CHEBI_
+                #  mesh: http://id.nlm.nih.gov/mesh/
+                #  orcid: https://orcid.org/
+                #  semapv: https://w3id.org/semapv/vocab/
+                #  skos: http://www.w3.org/2004/02/skos/core#
+                #mapping_date: '2026-05-04'
+                #mapping_set_id: {TEST_MAPPING_SET_ID}
+                subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification	author_id
+                mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration	{AUTHOR.curie}
+                mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration
+            """),  # noqa:E501
+            path_condensed.read_text(),
+            msg="subject/object labels and authors should not be included, "
+            "since they were not in the columns list",
+        )
+
+        path_uncondensed = self.directory.joinpath("test-uncondensed.sssom.tsv")
+        sssom_pydantic.write(
+            [m1, m2], path_uncondensed, converter=TEST_CONVERTER, metadata=metadata, condense=False
+        )
+        self.assertEqual(
+            dedent(f"""\
+                #curie_map:
+                #  chebi: http://purl.obolibrary.org/obo/CHEBI_
+                #  mesh: http://id.nlm.nih.gov/mesh/
+                #  orcid: https://orcid.org/
+                #  semapv: https://w3id.org/semapv/vocab/
+                #  skos: http://www.w3.org/2004/02/skos/core#
+                #mapping_set_id: {TEST_MAPPING_SET_ID}
+                subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification	author_id	mapping_date
+                mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration	{AUTHOR.curie}	2026-05-04
+                mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration		2026-05-04	
+            """),  # noqa:E501
+            path_uncondensed.read_text(),
+            msg="\nskipping condense failed",
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,10 +42,15 @@ class TestIO(cases.MappingTestCaseMixin):
         """Set up the test case."""
         self._tmp_directory = tempfile.TemporaryDirectory()
         self.directory = Path(self._tmp_directory.name)
+        self.path = self.directory.joinpath("test.sssom.tsv")
 
     def tearDown(self) -> None:
         """Tear down the test case."""
         self._tmp_directory.cleanup()
+
+    def assert_path(self, contents: str) -> None:
+        """Check the path has the right contents after dedenting."""
+        self.assertEqual(dedent(contents), self.path.read_text())
 
     def test_multivalued_record(self) -> None:
         """Test the Record class is properly type-annotated."""
@@ -455,32 +460,24 @@ class TestIO(cases.MappingTestCaseMixin):
 
     def test_write_explicit_columns(self) -> None:
         """Test writing with exclude."""
-        path = self.directory.joinpath("test.sssom.tsv")
-        metadata = MappingSet(id=TEST_MAPPING_SET_ID)
-        m = _m(authors=[AUTHOR])
         sssom_pydantic.write(
-            [m],
-            path,
+            [_m(authors=[AUTHOR])],
+            self.path,
             converter=TEST_CONVERTER,
-            metadata=metadata,
+            metadata=MappingSet(id=TEST_MAPPING_SET_ID),
             columns=["subject_id", "predicate_id", "object_id", "mapping_justification"],
         )
-        self.assertEqual(
-            dedent(f"""\
-                #curie_map:
-                #  chebi: http://purl.obolibrary.org/obo/CHEBI_
-                #  mesh: http://id.nlm.nih.gov/mesh/
-                #  orcid: https://orcid.org/
-                #  semapv: https://w3id.org/semapv/vocab/
-                #  skos: http://www.w3.org/2004/02/skos/core#
-                #mapping_set_id: {TEST_MAPPING_SET_ID}
-                subject_id	predicate_id	object_id	mapping_justification
-                mesh:C000089	skos:exactMatch	chebi:28646	semapv:ManualMappingCuration
-            """),
-            path.read_text(),
-            msg="subject/object labels and authors should not be included, "
-            "since they were not in the columns list",
-        )
+        self.assert_path(f"""\
+            #curie_map:
+            #  chebi: http://purl.obolibrary.org/obo/CHEBI_
+            #  mesh: http://id.nlm.nih.gov/mesh/
+            #  orcid: https://orcid.org/
+            #  semapv: https://w3id.org/semapv/vocab/
+            #  skos: http://www.w3.org/2004/02/skos/core#
+            #mapping_set_id: {TEST_MAPPING_SET_ID}
+            subject_id	predicate_id	object_id	mapping_justification
+            mesh:C000089	skos:exactMatch	chebi:28646	semapv:ManualMappingCuration
+        """)
 
     def test_toggle_condense(self) -> None:
         """Test toggling condense."""
@@ -535,3 +532,36 @@ class TestIO(cases.MappingTestCaseMixin):
             path_uncondensed.read_text(),
             msg="\nskipping condense failed",
         )
+
+    def test_toggle_subset_converter(self) -> None:
+        """Test toggling condense."""
+        sssom_pydantic.write(
+            [_m()],
+            self.path,
+            converter=TEST_CONVERTER,
+            metadata=MappingSet(id=TEST_MAPPING_SET_ID),
+            subset_converter=False,
+        )
+        self.assert_path(f"""\
+            #curie_map:
+            #  biolink: https://w3id.org/biolink/vocab/
+            #  bioregistry: https://bioregistry.io/
+            #  cas: https://commonchemistry.cas.org/detail?cas_rn=
+            #  chebi: http://purl.obolibrary.org/obo/CHEBI_
+            #  issue: https://github.com/cthoyt/sssom-pydantic/issues/
+            #  mesh: http://id.nlm.nih.gov/mesh/
+            #  orcid: https://orcid.org/
+            #  owl: http://www.w3.org/2002/07/owl#
+            #  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+            #  rdfs: http://www.w3.org/2000/01/rdf-schema#
+            #  rule: https://example.org/disease-rule/
+            #  semapv: https://w3id.org/semapv/vocab/
+            #  skos: http://www.w3.org/2004/02/skos/core#
+            #  spdx: https://spdx.org/licenses/
+            #  sssom: https://w3id.org/sssom/
+            #  sssom.record: https://w3id.org/sssom/record/
+            #  w3id: https://w3id.org/
+            #mapping_set_id: {TEST_MAPPING_SET_ID}
+            subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification
+            mesh:C000089	ammeline	skos:exactMatch	chebi:28646	ammeline	semapv:ManualMappingCuration
+        """)  # noqa:E501

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -540,7 +540,7 @@ class TestIO(cases.MappingTestCaseMixin):
             self.path,
             converter=TEST_CONVERTER,
             metadata=MappingSet(id=TEST_MAPPING_SET_ID),
-            subset_converter=False,
+            reduce_prefix_map=False,
         )
         self.assert_path(f"""\
             #curie_map:


### PR DESCRIPTION
This PR adds three new options for `sssom_pydantic.write`:

1. `subset_converter`, which when switched off, means that the records won't be passed over to collect all prefixes
2. `columns`, when passed explicitly, will tell sssom-pydantic which columns to write. This reduces the need to pass over all records to figure out which columns are used
3. `condense`, which when switched off, means the records won't be passed over to see which propagatable fields are single-valued

if `subset_converter=False`, `condense=False`, and giving an explict `columns` is done, then SSSOM can write in streaming mode