### PR TITLE
Implement workflow to merge manual curations

### DIFF
--- a/src/sssom_pydantic/process.py
+++ b/src/sssom_pydantic/process.py
@@ -854,6 +854,11 @@ def merge_manual_curations(
 
         The confidence estimation algorithm properly handles negative predicate
         modifiers as well as reviewer information.
+
+    .. warning::
+
+        This function partially scrambles the order of mappings. All non-merged mappings
+        come out in normal order, followed by merged mappings.
     """
     manual_curated_index = defaultdict(list)
     for mapping in mappings:

--- a/src/sssom_pydantic/process.py
+++ b/src/sssom_pydantic/process.py
@@ -47,6 +47,7 @@ __all__ = [
     "invert_by_object_prefix",
     "invert_by_prefix_pair",
     "invert_by_subject_prefix",
+    "merge_manual_curations",
     "publish",
     "remove_redundant_external",
     "remove_redundant_internal",

--- a/src/sssom_pydantic/process.py
+++ b/src/sssom_pydantic/process.py
@@ -828,5 +828,80 @@ def _so_prefixes(source_prefix: str, object_prefix: str) -> SemanticMappingPredi
     return _func
 
 
+def merge_manual_curations(
+    mappings: Iterable[MappingTypeVar],
+    *,
+    converter: curies.Converter,
+    precision: int | None = None,
+    confidence_model: ConfidenceModel | None = None,
+) -> Iterable[MappingTypeVar]:
+    r"""Merge manually curated mappings.
+
+    :param mappings: An iterable of semantic mappings
+    :param converter: A converter
+    :param precision: the precision to round newly calculated confidences
+    :param confidence_model: Which confidence model to use when aggregating mapping
+        confidences.
+
+        - mean aggregation is $\frac{1}{n} \sum_{i=1}^n c_i$
+        - binomial aggregation is $1 - \prod_{i=1}^n (1 - c_i)$
+
+    :returns: An iterable of semantic mappings, with manually curated mappings for the
+        same mapping triple merged together based on :func:`estimate_confidence`
+
+    .. note::
+
+        The confidence estimation algorithm properly handles negative predicate
+        modifiers as well as reviewer information.
+    """
+    manual_curated_index = defaultdict(list)
+    for mapping in mappings:
+        if mapping.justification == manual_mapping_curation:
+            manual_curated_index[mapping.as_str_triple()].append(mapping)
+        else:
+            yield mapping
+    for mapping_group in manual_curated_index.values():
+        if len(mapping_group) == 1:
+            yield mapping_group[0]
+        else:
+            yield _merge(
+                mapping_group,
+                converter=converter,
+                precision=precision,
+                confidence_model=confidence_model,
+            )
+
+
+def _merge(
+    mappings: list[MappingTypeVar],
+    *,
+    converter: curies.Converter,
+    precision: int | None = None,
+    confidence_model: ConfidenceModel | None = None,
+) -> MappingTypeVar:
+    """Merge manually curated mappings with the same s-p-o triple."""
+    authors = {author for mapping in mappings for author in mapping.authors or []}
+    confidence = estimate_confidence(
+        mappings, precision=precision, check=False, confidence_model=confidence_model
+    )
+    mapping = mappings[0]
+    data = {
+        "subject": mapping.subject,
+        "predicate": mapping.predicate,
+        "object": mapping.object,
+        "justification": mapping.justification,  # will always be manual curation, by construction
+        "authors": sorted(authors),
+        "confidence": confidence,
+        # TODO CC0 license?
+        "derived_from": [hash_triple_to_reference(mapping, converter) for mapping in mappings],
+    }
+    # look for matching fields
+    for slot_name in ["subject_source", "object_source"]:
+        values = {getattr(mapping, slot_name) for mapping in mappings}
+        if len(values) == 1 and (value := values.pop()) is not None:
+            data[slot_name] = value
+    return mapping.model_validate(data)
+
+
 if __name__ == "__main__":
     plot2d()

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -133,11 +133,19 @@ class MappingTestCaseMixin(unittest.TestCase):
         )
 
     def assert_model_sequence_equal(
-        self, expected: Iterable[SemanticMapping], actual: Iterable[SemanticMapping] | None
+        self,
+        expected: Iterable[SemanticMapping],
+        actual: Iterable[SemanticMapping] | None,
+        *,
+        sort: bool = False,
+        msg: str | None = None,
     ) -> None:
         """Assert two model sequences are equal."""
         if actual is None:
             raise self.fail()
+        if sort:
+            expected = sorted(expected)
+            actual = sorted(actual)
         return self.assertEqual(
             [
                 expected_mapping.model_dump(
@@ -155,6 +163,7 @@ class MappingTestCaseMixin(unittest.TestCase):
                 )
                 for actual_mapping in actual
             ],
+            msg=msg,
         )
 
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+from curies import NamedReference
 from curies.vocabulary import (
     broad_match,
     charlie,
@@ -22,7 +23,7 @@ from curies.vocabulary import (
 from sssom_pydantic import SemanticMapping, hash_triple_to_reference
 from sssom_pydantic import process as pr
 from sssom_pydantic.api import NOT
-from sssom_pydantic.examples import TEST_CONVERTER
+from sssom_pydantic.examples import R3, R4, R5, R6, TEST_CONVERTER
 from sssom_pydantic.process import (
     InvalidExistsActionError,
     Mark,
@@ -643,3 +644,68 @@ class TestProcess(cases.MappingTestCaseMixin):
                 justification_policy=pr.InversionJustificationPolicy.derive,
             ),
         )
+
+
+ambika = NamedReference.from_curie("orcid:0009-0009-1663-1003", name="Ambika Gupta ")
+
+
+class TestMergeManual(cases.MappingTestCaseMixin):
+    """Test merging manually curated things."""
+
+    def test_merge_utility(self) -> None:
+        """Test merging manually curated mappings."""
+        mappings = [
+            _m(authors=[charlie], confidence=0.9),
+            _m(authors=[ambika], confidence=0.8, comment="something"),
+        ]
+        expected = _m(
+            authors=[charlie, ambika],
+            confidence=0.85,
+            derived_from=[hash_triple_to_reference(m, TEST_CONVERTER) for m in mappings],
+        )
+        res = pr._merge(mappings, converter=TEST_CONVERTER, precision=4)
+        self.assert_model_equal(expected, res)
+
+    def test_full(self) -> None:
+        """Test full workflow."""
+        a = _m(
+            authors=[charlie],
+            justification=manual_mapping_curation,
+            confidence=0.9,
+            subject_source="obo:mesh",
+        )
+        b = _m(
+            authors=[ambika],
+            justification=manual_mapping_curation,
+            confidence=0.8,
+            comment="something",
+            subject_source="obo:mesh",
+        )
+
+        mappings = [
+            # the first _m with lexical won't get counted
+            _m(justification=lexical_matching_process, confidence=0.3),
+            a,
+            b,
+            SemanticMapping.exact(R3, R4),  # wrong justification
+            SemanticMapping.exact(
+                R5, R6, justification=manual_mapping_curation
+            ),  # wrong justification
+        ]
+        actual = pr.merge_manual_curations(mappings, converter=TEST_CONVERTER, precision=3)
+        expected = [
+            _m(justification=lexical_matching_process, confidence=0.3),
+            SemanticMapping.exact(R3, R4),
+            SemanticMapping.exact(R5, R6, justification=manual_mapping_curation),
+            _m(
+                authors=[charlie, ambika],
+                justification=manual_mapping_curation,
+                confidence=0.85,
+                derived_from=[
+                    hash_triple_to_reference(a, TEST_CONVERTER),
+                    hash_triple_to_reference(b, TEST_CONVERTER),
+                ],
+                subject_source="obo:mesh",
+            ),
+        ]
+        self.assert_model_sequence_equal(expected, actual, sort=True)


### PR DESCRIPTION
Closes #132

This PR implements the `sssom_pydantic.process.merge_manual_curations()` workflow, which groups mappings based on their confidences estimated by #62 and refers to the original mappings using `derived_from`