### PR TITLE
Don't include `derived_from` unless using the `derive` policy

### DIFF
--- a/src/sssom_pydantic/process.py
+++ b/src/sssom_pydantic/process.py
@@ -876,11 +876,21 @@ def invert_by_prefix_pair(
     >>> m1_inv = SemanticMapping.exact(
     ...     "CHEBI:28646",
     ...     "mesh:C000089",
-    ...     derived_from=[hash_triple_to_reference(m1, converter)],
     ... )
     >>> m2 = SemanticMapping.exact("CHEBI:10001", "mesh:C067604")
     >>> assert [m1_inv, m2] == list(
     ...     invert_by_prefix_pair([m1, m2], "mesh", "CHEBI", converter=converter)
+    ... )
+    >>> m1_inv_derive = SemanticMapping.exact(
+    ...     "CHEBI:28646",
+    ...     "mesh:C000089",
+    ...     justification=mapping_inversion,
+    ...     derived_from=[hash_triple_to_reference(m1, converter)],
+    ... )
+    >>> assert [m1_inv_derive, m2] == list(
+    ...     invert_by_prefix_pair(
+    ...         [m1, m2], "mesh", "CHEBI", converter=converter, justification_policy="derive"
+    ...     )
     ... )
     """
     yield from invert_by_predicate(

--- a/src/sssom_pydantic/process.py
+++ b/src/sssom_pydantic/process.py
@@ -412,7 +412,11 @@ def invert(
     ... )
     >>> hash_triple_to_reference(mapping, converter)
     Reference(prefix='mapping', identifier='36a1f9244ea7641a90987c82f33c25c0c13712ee8f48207b2a0825f8a4e4e26a')
-    >>> mapping_inv = invert(mapping, converter=converter)
+    >>> mapping_inv = invert(
+    ...     mapping,
+    ...     converter=converter,
+    ...     justification_policy=InversionJustificationPolicy.derive,
+    ... )
     >>> mapping_inv.subject
     NamableReference(prefix='CHEBI', identifier='28646', name='ammeline')
     >>> mapping_inv.object

--- a/src/sssom_pydantic/process.py
+++ b/src/sssom_pydantic/process.py
@@ -761,13 +761,20 @@ def invert_by_subject_prefix(
     ...     }
     ... )
     >>> m1 = SemanticMapping.exact("mesh:C000089", "CHEBI:28646")
-    >>> m1_inv = SemanticMapping.exact(
-    ...     "CHEBI:28646",
-    ...     "mesh:C000089",
-    ...     derived_from=[hash_triple_to_reference(m1, converter)],
-    ... )
+    >>> m1_inv = SemanticMapping.exact("CHEBI:28646", "mesh:C000089")
     >>> m2 = SemanticMapping.exact("CHEBI:10001", "mesh:C067604")
     >>> assert [m1_inv, m2] == list(invert_by_subject_prefix([m1, m2], "mesh", converter=converter))
+    >>> m1_inv_derive = SemanticMapping.exact(
+    ...     "CHEBI:28646",
+    ...     "mesh:C000089",
+    ...     justification=mapping_inversion,
+    ...     derived_from=[hash_triple_to_reference(m1, converter)],
+    ... )
+    >>> assert [m1_inv_derive, m2] == list(
+    ...     invert_by_subject_prefix(
+    ...         [m1, m2], "mesh", converter=converter, justification_policy="derive"
+    ...     )
+    ... )
     """
     yield from invert_by_predicate(
         mappings,
@@ -816,13 +823,20 @@ def invert_by_object_prefix(
     ...     }
     ... )
     >>> m1 = SemanticMapping.exact("mesh:C000089", "CHEBI:28646")
-    >>> m1_inv = SemanticMapping.exact(
-    ...     "CHEBI:28646",
-    ...     "mesh:C000089",
-    ...     derived_from=[hash_triple_to_reference(m1, converter)],
-    ... )
+    >>> m1_inv = SemanticMapping.exact("CHEBI:28646", "mesh:C000089")
     >>> m2 = SemanticMapping.exact("CHEBI:10001", "mesh:C067604")
     >>> assert [m1_inv, m2] == list(invert_by_object_prefix([m1, m2], "CHEBI", converter=converter))
+    >>> m1_inv_derive = SemanticMapping.exact(
+    ...     "CHEBI:28646",
+    ...     "mesh:C000089",
+    ...     justification=mapping_inversion,
+    ...     derived_from=[hash_triple_to_reference(m1, converter)],
+    ... )
+    >>> assert [m1_inv_derive, m2] == list(
+    ...     invert_by_object_prefix(
+    ...         [m1, m2], "CHEBI", converter=converter, justification_policy="derive"
+    ...     )
+    ... )
     """
     yield from invert_by_predicate(
         mappings,

--- a/src/sssom_pydantic/process.py
+++ b/src/sssom_pydantic/process.py
@@ -441,6 +441,7 @@ def invert(
 
     if justification_policy is InversionJustificationPolicy.derive:
         update["justification"] = mapping_inversion
+        update["derived_from"] = [hash_triple_to_reference(mapping, converter)]
 
     for part in _EXCHANGEABLE_FIELDS:
         subject_part = getattr(mapping, f"subject_{part}")
@@ -454,8 +455,6 @@ def invert(
         else:  # elif object_part
             update[f"object_{part}"] = None
             update[f"subject_{part}"] = object_part
-
-    update["derived_from"] = [hash_triple_to_reference(mapping, converter)]
 
     return mapping.model_copy(update=update)
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -559,11 +559,7 @@ class TestProcess(cases.MappingTestCaseMixin):
             justification=mapping_inversion,
             derived_from=[hash_triple_to_reference(m1, TEST_CONVERTER)],
         )
-        m1_inv_retain = SemanticMapping.exact(
-            "CHEBI:28646",
-            "mesh:C000089",
-            derived_from=[hash_triple_to_reference(m1, TEST_CONVERTER)],
-        )
+        m1_inv_retain = SemanticMapping.exact("CHEBI:28646", "mesh:C000089")
         m2 = SemanticMapping.exact("CHEBI:10001", "mesh:C067604")
         assert_semantic_mappings_equal(
             self,
@@ -597,11 +593,7 @@ class TestProcess(cases.MappingTestCaseMixin):
             justification=mapping_inversion,
             derived_from=[hash_triple_to_reference(m1, TEST_CONVERTER)],
         )
-        m1_inv_retain = SemanticMapping.exact(
-            "CHEBI:28646",
-            "mesh:C000089",
-            derived_from=[hash_triple_to_reference(m1, TEST_CONVERTER)],
-        )
+        m1_inv_retain = SemanticMapping.exact("CHEBI:28646", "mesh:C000089")
         m2 = SemanticMapping.exact("CHEBI:10001", "mesh:C067604")
         assert_semantic_mappings_equal(
             self,
@@ -650,12 +642,8 @@ class TestProcess(cases.MappingTestCaseMixin):
         m0 = SemanticMapping.exact(R1, R2)
         m1 = SemanticMapping.narrow(R1, R2)
         m2 = SemanticMapping.broad(R2, R1)
-        m1_derived = SemanticMapping.narrow(
-            R1, R2, derived_from=[hash_triple_to_reference(m2, TEST_CONVERTER)]
-        )
-        m2_derived = SemanticMapping.broad(
-            R2, R1, derived_from=[hash_triple_to_reference(m1, TEST_CONVERTER)]
-        )
+        m1_derived = SemanticMapping.narrow(R1, R2)
+        m2_derived = SemanticMapping.broad(R2, R1)
         self.assert_model_sequence_equal(
             [m0, m2_derived], pr.invert_narrow_matches([m0, m1], converter=TEST_CONVERTER)
         )
@@ -674,7 +662,7 @@ class TestProcess(cases.MappingTestCaseMixin):
         self.assert_model_sequence_equal([m1], pr.filter_by_confidence([m1, m2, m3], 0.95))
 
 
-ambika = NamedReference.from_curie("orcid:0009-0009-1663-1003", name="Ambika Gupta ")
+ambika = NamedReference.from_curie("orcid:0009-0009-1663-1003", name="Ambika Gupta")
 
 
 class TestMergeManual(cases.MappingTestCaseMixin):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -642,13 +642,11 @@ class TestProcess(cases.MappingTestCaseMixin):
         m0 = SemanticMapping.exact(R1, R2)
         m1 = SemanticMapping.narrow(R1, R2)
         m2 = SemanticMapping.broad(R2, R1)
-        m1_derived = SemanticMapping.narrow(R1, R2)
-        m2_derived = SemanticMapping.broad(R2, R1)
         self.assert_model_sequence_equal(
-            [m0, m2_derived], pr.invert_narrow_matches([m0, m1], converter=TEST_CONVERTER)
+            [m0, m2], pr.invert_narrow_matches([m0, m1], converter=TEST_CONVERTER)
         )
         self.assert_model_sequence_equal(
-            [m0, m1_derived], pr.invert_broad_matches([m0, m2], converter=TEST_CONVERTER)
+            [m0, m1], pr.invert_broad_matches([m0, m2], converter=TEST_CONVERTER)
         )
 
     def test_filter_by_confidence(self) -> None:


### PR DESCRIPTION
When using the "retain" (default) policy, you should just assume that it's a primary evidence and not need to point back to the _actual_ primary evidence.